### PR TITLE
YML root --> workdir

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -415,9 +415,9 @@ func RunCommands(config BuildConfiguration) ([]CommandTimer, error) {
 			//os.Chdir(dir)
 			targetDir = dir
 		} else {
-			if target.Root != "" {
-				fmt.Printf("Build root is %s\n", target.Root)
-				targetDir = filepath.Join(targetDir, target.Root)
+			if target.WorkDir != "" {
+				fmt.Printf("Build root is %s\n", target.WorkDir)
+				targetDir = filepath.Join(targetDir, target.WorkDir)
 			}
 
 			if sandboxed {

--- a/cli/build.go
+++ b/cli/build.go
@@ -416,7 +416,7 @@ func RunCommands(config BuildConfiguration) ([]CommandTimer, error) {
 			targetDir = dir
 		} else {
 			if target.WorkDir != "" {
-				fmt.Printf("Build root is %s\n", target.WorkDir)
+				fmt.Printf("Workdir is %s\n", target.WorkDir)
 				targetDir = filepath.Join(targetDir, target.WorkDir)
 			}
 

--- a/types/types.go
+++ b/types/types.go
@@ -71,7 +71,7 @@ type BuildTarget struct {
 	Artifacts   []string            `yaml:"artifacts"`
 	CachePaths  []string            `yaml:"cache_paths"`
 	Sandbox     bool                `yaml:"sandbox"`
-	Root        string              `yaml:"root"`
+	WorkDir     string              `yaml:"workdir"`
 	Environment []string            `yaml:"environment"`
 	Tags        map[string]string   `yaml:"tags"`
 	BuildAfter  []string            `yaml:"build_after"`


### PR DESCRIPTION
Using "root" to specify a different working directory is confusing, so proposing, as @nictuku mentioned, this fix. It would break old `.yourbase.yml` files.