### PR TITLE
YML fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.vim
 yb
 .DS_Store
+release

--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -8,6 +8,12 @@ build_targets:
     host_only: true
     commands:
       - go test ./...
+      - go build
+
+  - name: development
+    host_only: true
+    commands:
+      - go test ./...
       - go build -ldflags "-X 'main.channel=development'"
 
     # Tagged releases will go to unstable

--- a/gh_release.sh
+++ b/gh_release.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -x
+
+PROJECT="yb"
+
+if [ -z "${VERSION}" ]; then
+  echo "No version provided, won't release"
+  exit 1
+fi
+
+if [ -z "${CHANNEL}" ]; then
+  echo "Channel not set, will release as unstable"
+  CHANNEL="unstable"
+fi
+
+if [ "${CHANNEL}" == "preview" ]; then
+  echo "Channel is preview, setting version to timestamp"
+  VERSION="$(date +"%Y%m%d%H%M%S")"
+fi
+
+umask 077
+
+# Now releasing to GH (but need manual upload)
+echo "Releasing local yb version ${VERSION}..."
+
+rm -rf release
+mkdir -p release
+
+OSLIST=( linux darwin )
+ARCHLIST=( amd64 )
+
+for os in "${OSLIST[@]}"
+do
+  for arch in "${ARCHLIST[@]}"
+  do
+    GOOS=${os} GOARCH=${arch} go build -ldflags "-X 'main.version=$VERSION' -X 'main.buildDate=$(date)' -X 'main.channel=$CHANNEL'" -o release/yb-${os}-${arch}-${CHANNEL}
+    if [ "$os" == "linux" ]; then
+        xz -ve release/yb-${os}-${arch}-${CHANNEL}
+        echo "Please upload release/yb-${os}-${arch}-${CHANNEL}.zx to a GH release"
+    else
+        zip -v release/yb-${os}-${arch}-${CHANNEL} release/yb-${os}-${arch}-${CHANNEL}
+        rm release/yb-${os}-${arch}-${CHANNEL} 
+        echo "Please upload release/yb-${os}-${arch}-${CHANNEL}.zip to a GH release"
+    fi
+  done
+done

--- a/gh_release.sh
+++ b/gh_release.sh
@@ -37,6 +37,7 @@ do
     GOOS=${os} GOARCH=${arch} go build -ldflags "-X 'main.version=$VERSION' -X 'main.buildDate=$(date)' -X 'main.channel=$CHANNEL'" -o release/yb-${os}-${arch}-${CHANNEL}
     if [ "$os" == "linux" ]; then
         xz -ve release/yb-${os}-${arch}-${CHANNEL}
+        chmod -x release/yb-${os}-${arch}-${CHANNEL}.xz
         echo "Please upload release/yb-${os}-${arch}-${CHANNEL}.zx to a GH release"
     else
         zip -v release/yb-${os}-${arch}-${CHANNEL} release/yb-${os}-${arch}-${CHANNEL}


### PR DESCRIPTION
After merging `quicker-remotebuild` branch, I suspect that the change to `.yourbase.yml` would overwrite any external setting to the `$CHANNEL` var, so I think we should use this fix. Also created a `gh_release.sh`, so binaries can be available at GitHub release too. (Still manually, but works)