### PR TITLE
Update README.md: Merge the getting started page into the open-source doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,104 @@ The primary features of the YB tooling are:
 3. Write a simple build manifest (more below)
 4. Build awesome things!
 
-# Documentation 
+# Getting Started
 
-See http://docs.yourbase.io.
+To use yb you need a `.yourbase.yml` file in your repository with
+enough information to build your project:
+
+## Example .yourbase.yml
+
+```
+dependencies:
+   build:
+     - python:3.6.3
+
+build_targets:
+   - name: default
+     commands:
+       - pip install -r requirements.txt
+       - python tests/run_tests.py 
+
+ci:
+  builds:
+    - name: tests
+      build_target: default
+```
+
+The YourBase config was designed from the ground up to be a fast, composable
+and easy to use method to declare build targets. Targets defined in the config
+are built in an isolated and uniform container, so local builds are similar to
+remote builds.
+
+The YourBase YAML replaces both legacy CI configs and container build
+configuration formats like Dockerfile. It uses containers underneath and you can
+still run things on the side like MySQL, Postgres, Redis or any service from a
+container image.
+
+For more examples and a complete reference to the YAML configuration syntax,
+see https://docs.yourbase.io/configuration/yourbase_yaml.html
+
+## Test the .yourbase.yml
+
+You can test the configuration locally before committing it by calling `yb checkconfig` in the the root directory of your repository:
+
+`yb checkconfig`
+
+Make sure you have a `.yourbase.yml` file in that directory.
+
+## Run your first local build
+
+If you created a `default` target, you can build it with:
+
+`yb build`
+
+Or if you have a different `build_target`, try:
+
+`yb build <target name>`
+
+## Run the first remote build
+
+To use remote builds, first you have to sign-in to YourBase.io with. Run this to get a sign-in URL:
+
+`yb login`
+
+Then try to run a remote build. To build the `default` target, just do:
+
+`yb remotebuild`
+
+or if you have a different target in your config:
+
+`yb remotebuild <target>`
+
+You can watch the build/test stream both locally and in the build dashboard at https://app.yourbase.io
+
+## Triggering Builds from GitHub pushes
+
+You can also build code after it's pushed to a GitHub repository. Install the
+  free `YourBase Accelerated CI app for GitHub` at https://github.com/apps/yourbase. 
+
+Then push any change to GitHub, on any branch. If the `.yourbase.yml` file is in that change and is valid, you should see your build in the dashboard.
+
+  - YourBase GitHub app: https://github.com/apps/yourbase
+  - Dashboard: https://app.yourbase.io
+
+### Build Conditions
+
+By default, the YourBase Accelerated CI runs the specified build targets whenever there is
+a GitHub push event. You can change it to only build after certain events,
+by specifying conditions for build service builds:
+
+```
+   ci:
+     builds:
+       - name: tests
+         build_target: default
+         when: branch is 'master' OR action is 'pull_request'
+```
+
+# Documentation
+
+See the complete documentation and configuration reference at http://docs.yourbase.io.
 
 # Self-update
 


### PR DESCRIPTION
I already merged the other PR about remote builds. So #48 may conflict, this one would not.