### PR TITLE
add url list when project fetch fails

### DIFF
--- a/cli/remote_build.go
+++ b/cli/remote_build.go
@@ -622,6 +622,8 @@ func defineBranch(r *git.Repository, hintBranch string) (string, error) {
 func (p *RemoteCmd) fetchProject(urls []string) (*Project, GitRemote, error) {
 	var empty GitRemote
 	v := url.Values{}
+	urlsList := fmt.Sprintf("URL's used to do the search: %s", urls)
+
 	for _, u := range urls {
 		rem := NewGitRemote(u)
 		// We only support GitHub by now
@@ -636,18 +638,18 @@ func (p *RemoteCmd) fetchProject(urls []string) (*Project, GitRemote, error) {
 	resp, err := postToApi("search/projects", v)
 
 	if err != nil {
-		return nil, empty, fmt.Errorf("Couldn't lookup project on api server: %v", err)
+		return nil, empty, fmt.Errorf("Couldn't lookup project on api server: %v.\n%s", err, urlsList)
 	}
 
 	if resp.StatusCode != 200 {
 		if resp.StatusCode == 400 {
-			return nil, empty, fmt.Errorf("This is us, not you, please try again in a few minutes.")
+			return nil, empty, fmt.Errorf("This is us, not you, please try again in a few minutes.\n%s", urlsList)
 		} else if resp.StatusCode == 203 {
 			p.publicRepo = true
 		} else if resp.StatusCode == 401 {
 			return nil, empty, fmt.Errorf("Unauthorized, authentication failed.\nPlease `yb login` again.")
 		} else {
-			return nil, empty, fmt.Errorf("Error fetching project from API.")
+			return nil, empty, fmt.Errorf("Error fetching project from API.\n%s", urlsList)
 		}
 	}
 
@@ -661,7 +663,7 @@ func (p *RemoteCmd) fetchProject(urls []string) (*Project, GitRemote, error) {
 
 	remote := p.pickRemote(project.Repository)
 	if !remote.Validate() {
-		return nil, empty, fmt.Errorf("Can't pick a good remote to clone upstream")
+		return nil, empty, fmt.Errorf("Can't pick a good remote to clone upstream.\n%s", urlsList)
 	}
 
 	return &project, remote, nil

--- a/cli/remote_build.go
+++ b/cli/remote_build.go
@@ -622,7 +622,7 @@ func defineBranch(r *git.Repository, hintBranch string) (string, error) {
 func (p *RemoteCmd) fetchProject(urls []string) (*Project, GitRemote, error) {
 	var empty GitRemote
 	v := url.Values{}
-	urlsList := fmt.Sprintf("URL's used to do the search: %s", urls)
+	log.Infof("URL's used to do the search: %s", urls)
 
 	for _, u := range urls {
 		rem := NewGitRemote(u)
@@ -638,18 +638,18 @@ func (p *RemoteCmd) fetchProject(urls []string) (*Project, GitRemote, error) {
 	resp, err := postToApi("search/projects", v)
 
 	if err != nil {
-		return nil, empty, fmt.Errorf("Couldn't lookup project on api server: %v.\n%s", err, urlsList)
+		return nil, empty, fmt.Errorf("Couldn't lookup project on api server: %v", err)
 	}
 
 	if resp.StatusCode != 200 {
 		if resp.StatusCode == 400 {
-			return nil, empty, fmt.Errorf("This is us, not you, please try again in a few minutes.\n%s", urlsList)
+			return nil, empty, fmt.Errorf("This is us, not you, please try again in a few minutes.")
 		} else if resp.StatusCode == 203 {
 			p.publicRepo = true
 		} else if resp.StatusCode == 401 {
 			return nil, empty, fmt.Errorf("Unauthorized, authentication failed.\nPlease `yb login` again.")
 		} else {
-			return nil, empty, fmt.Errorf("Error fetching project from API.\n%s", urlsList)
+			return nil, empty, fmt.Errorf("Error fetching project from API.")
 		}
 	}
 
@@ -663,7 +663,7 @@ func (p *RemoteCmd) fetchProject(urls []string) (*Project, GitRemote, error) {
 
 	remote := p.pickRemote(project.Repository)
 	if !remote.Validate() {
-		return nil, empty, fmt.Errorf("Can't pick a good remote to clone upstream.\n%s", urlsList)
+		return nil, empty, fmt.Errorf("Can't pick a good remote to clone upstream.")
 	}
 
 	return &project, remote, nil


### PR DESCRIPTION
https://app.clubhouse.io/yourbaseio/story/827/when-yb-remotebuild-fails-to-find-project-in-the-api-show-which-project-it-tried-to-find

Shows up the list of URL used to fetch the project from the build server (API).

This applies over #51 