### PR TITLE
stable auto release, preview releases as full versions

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -30,6 +30,7 @@ build_targets:
     build_after:
       - default
     environment:
+      - pip install awscli
       - CHANNEL=preview
     commands:
       - bash release.sh 
@@ -63,7 +64,7 @@ ci:
 
     - name: preview_release
       build_target: preview_release
-      when: branch IS NOT 'master' AND tagged IS false
+      when: branch IS NOT 'master'
 
     - name: release
       build_target: release

--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -30,9 +30,9 @@ build_targets:
     build_after:
       - default
     environment:
-      - pip install awscli
       - CHANNEL=preview
     commands:
+      - pip install awscli
       - bash release.sh 
 
   - name: linux

--- a/gh_release.sh
+++ b/gh_release.sh
@@ -1,5 +1,53 @@
 #!/bin/bash
 
+# After finishing https://github.com/yourbase/buildagent/tree/metadata, we'll have enought env variables to fill this and use this function, but inside `./release.sh`
+
+function gh_upload_release_asset(repo, owner, tag, github_api_token, filename) {
+    # Got from https://gist.github.com/stefanbuck/ce788fee19ab6eb0b4447a85fc99f447
+    # Define variables.
+    GH_API="https://api.github.com"
+    GH_REPO="$GH_API/repos/$owner/$repo"
+    GH_TAGS="$GH_REPO/releases/tags/$tag"
+    AUTH="Authorization: token $github_api_token"
+    WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
+    CURL_ARGS="-LJO#"
+
+    # if [[ "$tag" == 'LATEST' ]]; then
+    #   GH_TAGS="$GH_REPO/releases/latest"
+    # fi
+
+    # Validate token.
+    curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
+
+    # Read asset tags.
+    response=$(curl -sH "$AUTH" $GH_TAGS)
+
+    # Get ID of the release.
+    eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
+    [ "$id" ] || { echo "Error: Failed to get release id for tag: $tag"; echo "$response" | awk 'length($0)<100' >&2; exit 1; }
+    release_id="$id"
+
+    # Get ID of the asset based on given filename.
+    id=""
+    eval $(echo "$response" | grep -C1 "name.:.\+$filename" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
+    assert_id="$id"
+    if [ "$assert_id" = "" ]; then
+        echo "No need to overwrite asset"
+    else
+        echo "Deleting asset($assert_id)... "
+        curl "$GITHUB_OAUTH_BASIC" -X "DELETE" -H "Authorization: token $github_api_token" "https://api.github.com/repos/$owner/$repo/releases/assets/$assert_id"
+    fi
+
+    # Upload asset
+    echo "Uploading asset... "
+
+    # Construct url
+    GH_ASSET="https://uploads.github.com/repos/$owner/$repo/releases/$release_id/assets?name=$(basename $filename)"
+
+    curl "$GITHUB_OAUTH_BASIC" --data-binary @"$filename" -H "Authorization: token $github_api_token" -H "Content-Type: application/octet-stream" $GH_ASSET
+}
+
+
 set -x
 
 PROJECT="yb"

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 APP="app_gtQEt1zkGMj"
 PROJECT="yb"
 TOKEN="${RELEASE_TOKEN}"
@@ -17,7 +15,7 @@ if [ -z "${VERSION}" ]; then
   exit 1
 fi
 
-STABLE_TAGGED="$(echo $VERSION | grep -o '-stable')"
+STABLE_TAGGED="$(echo $VERSION | grep -o '\-stable')"
 
 if [ -z "${CHANNEL}" ]; then
   echo "Channel not set, will release as unstable"
@@ -25,6 +23,10 @@ if [ -z "${CHANNEL}" ]; then
 fi
 
 if [ "${STABLE_TAGGED}" == "-stable" ]; then
+    # Strips stable
+    STRIPPED_VERSION="$(echo "$VERSION" | sed -e 's/-stable.*//g')"
+    echo "Stable version $VERSION becomes $STRIPPED_VERSION, so decided to release as stable"
+    VERSION=$STRIPPED_VERSION
     CHANNEL="stable"
 fi
 
@@ -35,6 +37,8 @@ cleanup() {
     rm -rf "$tmpkeyfile"
     exit $rv
 }
+
+set -x
 
 tmpkeyfile="$(mktemp)"
 trap "cleanup" INT TERM EXIT

--- a/release.sh
+++ b/release.sh
@@ -17,20 +17,15 @@ if [ -z "${VERSION}" ]; then
   exit 1
 fi
 
+STABLE_TAGGED="$(echo $VERSION | grep -o '-stable')"
+
 if [ -z "${CHANNEL}" ]; then
   echo "Channel not set, will release as unstable"
-  echo "To promote to a new channel, use the equinox release tool:"
-  echo '$ equinox publish --token $TOKEN --app $APP  --channel stable --release 0.0.39'
   CHANNEL="unstable"
 fi
 
-if [ "${CHANNEL}" == "preview" ]; then
-  echo "Channel is preview, setting version to timestamp"
-  VERSION="$(date +"%Y%m%d%H%M%S")"
-elif [ "${CHANNEL}" == "stable" ]; then
-  echo "To promote to stable, use the equinox release tool:"
-  echo '$ equinox publish --token $TOKEN --app $APP  --channel stable --release $VERSION'
-  exit 0
+if [ "${STABLE_TAGGED}" == "-stable" ]; then
+    CHANNEL="stable"
 fi
 
 umask 077
@@ -61,11 +56,7 @@ tar zxvf release-tool-stable-linux-amd64.tgz
 	-ldflags "-X main.version=$VERSION -X 'main.date=$(date)' -X main.channel=$CHANNEL" \
 	"github.com/yourbase/${PROJECT}"
 
-if [ "${CHANNEL}" == "preview" ]; then
-    exit 0
-fi
-
-# Now releasing to S3
+# Now releasing to S3 and GH
 echo "Releasing yb version ${VERSION}..."
 
 rm -rf release


### PR DESCRIPTION
If a tag has '-stable' in it, change channel to stable, and run equinox in our build servers as it would for preview and unstable.

Made preview work as a version, so we can better identify preview versions too, and track them closer to unstable/stable.