### PR TITLE
only release if we have a tag

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -62,11 +62,11 @@ ci:
     - name: test_build
       build_target: default
 
-    - name: preview_release
+    - name: pre_release
       build_target: preview_release
-      when: branch IS NOT 'master'
+      when: branch IS NOT 'master' AND tagged IS true
 
     - name: release
       build_target: release
-      when: tagged IS true
+      when: branch IS 'master' AND tagged IS true
 


### PR DESCRIPTION
keeping my theory that is more useful to release software with versions, instead of dates. Forgot about this.