### PR TITLE
aligned with V2 UI

### DIFF
--- a/cli/remote_build.go
+++ b/cli/remote_build.go
@@ -178,7 +178,7 @@ func (p *RemoteCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	}
 
 	if project.Repository == "" {
-		projectUrl, err := ybconfig.ManagementUrl(fmt.Sprintf("%s/%s", project.OrgSlug, project.Label))
+		projectUrl, err := ybconfig.ManagementUrl(fmt.Sprintf("/organizations/%s/projects/%s", project.OrgSlug, project.Label))
 		bootErrored()
 		if err != nil {
 			log.Errorf("Unable to generate project URL: %v", err)
@@ -581,7 +581,7 @@ func managementLogUrl(url, org, label string) string {
 			return ""
 		}
 
-		u, err := ybconfig.ManagementUrl(fmt.Sprintf("/%s/%s/builds/%s", org, label, build))
+		u, err := ybconfig.ManagementUrl(fmt.Sprintf("/organizations/%s/projects/%s/builds/%s", org, label, build))
 		if err != nil {
 			log.Errorf("Unable to generate App Url: %v", err)
 		}


### PR DESCRIPTION
That's about right, I think. Now the path scheme is `/organizations/<org slug>/projects/<project label>/builds/<UUID | ID>`. Right?