### PR TITLE
pypred may need ()

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -62,11 +62,11 @@ ci:
     - name: test_build
       build_target: default
 
-    - name: pre_release
-      build_target: preview_release
-      when: branch IS NOT 'master' AND tagged IS true
-
     - name: release
       build_target: release
       when: branch IS 'master' AND tagged IS true
+
+    - name: pre_release
+      build_target: preview_release
+      when: (branch IS NOT 'master') AND tagged IS true
 


### PR DESCRIPTION
To auto release correctly. Somehow `PyPred` didn't understand `branch IS NOT 'master'` without parenthesis.