### PR TITLE
Fix the download URL to support other than OpenJDK 8

### DIFF
--- a/buildpacks/openjdk.go
+++ b/buildpacks/openjdk.go
@@ -58,6 +58,8 @@ func NewJavaBuildTool(toolSpec BuildToolSpec) JavaBuildTool {
 		subVersion = "10"
 	case 13:
 		subVersion = "8"
+	case 14:
+		subVersion = "36"
 	default:
 		subVersion = ""
 	}


### PR DESCRIPTION
Tested by specifying the latest version of OpenJDK 11 (11.0.6) and it works