### PR TITLE
Add Homebrew installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,16 @@ The primary features of the YB tooling are:
 
 # How to use it
 
-1. Install docker if you don't have it: https://hub.docker.com/search/?type=edition&offering=community (we know this can be annoying,  sorry about that)
-1. Download and install `yb` from https://dl.equinox.io/yourbase/yb/stable - alternatively, build the code in this repository using `go build` with a recent version of go. 
+1. Install Docker if you don't have it: https://hub.docker.com/search/?type=edition&offering=community (we know this can be annoying,  sorry about that)
+1. Download and install `yb`. You can do this using Homebrew:
+    ```sh
+    brew install yourbase/core/yb
+    ```
+    Or by building it yourself with a recent version of Go:
+    ```sh
+    go get -u github.com/yourbase/yb
+    ```
+    Or by downloading the binary: https://dl.equinox.io/yourbase/yb/stable
 1. Clone a package from GitHub 
 1. Write a simple build manifest (more below)
 1. Build awesome things!


### PR DESCRIPTION
I've added a custom tap for `yb` at [yourbase/homebrew-core](https://github.com/yourbase/homebrew-core), so we can now install using
```sh
brew install yourbase/core/yb
```
The custom tap will automatically update from upstream as we push updates to Equinox.