### PR TITLE
Feature/support new flutter version

### DIFF
--- a/buildpacks/flutter.go
+++ b/buildpacks/flutter.go
@@ -70,9 +70,7 @@ func (bt FlutterBuildTool) DownloadUrl() string {
 		downloadUrlVersion(version),
 		extension,
 	}
-	mirror := FLUTTER_DIST_MIRROR
-
-	url, _ := TemplateToString(mirror, data)
+	url, _ := TemplateToString(FLUTTER_DIST_MIRROR, data)
 
 	return url
 }

--- a/buildpacks/flutter.go
+++ b/buildpacks/flutter.go
@@ -143,8 +143,11 @@ func (bt FlutterBuildTool) Install() error {
 //   https://storage.googleapis.com/.../flutter_windows_1.17.0-stable.zip)
 //
 // Also, yb tacks on a v for customers when we build the URL.
-// This function will be backaward compatible (tack on "v"), it will support pre 1.17
+// This function will be backward compatible (tack on "v"), it will support pre 1.17
 // version with a "v", and support 1.17 and greater
+//
+// Note: We are predicting the future since they could require a "v" again if 1.17.0
+// was a mistake
 //
 func downloadUrlVersion(version string) string {
 	version_1_17_0 := "v1.17.0"
@@ -155,8 +158,11 @@ func downloadUrlVersion(version string) string {
 		compVersion = fmt.Sprintf("v%s", version)
 	}
 
+	// Below 1.17.0 need the "v", >= to 1.17.0, remove the "v"
 	if semver.Compare(compVersion, version_1_17_0) < 0 {
-		version = compVersion
+		version = compVersion // Need the "v"
+	} else {
+		version = strings.TrimLeft(compVersion, "v")
 	}
 
 	return version

--- a/buildpacks/flutter.go
+++ b/buildpacks/flutter.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"golang.org/x/mod/semver"
 
 	. "github.com/yourbase/yb/plumbing"
 	"github.com/yourbase/yb/plumbing/log"
@@ -14,7 +15,7 @@ import (
 )
 
 // https://archive.apache.org/dist/flutter/flutter-3/3.3.3/binaries/apache-flutter-3.3.3-bin.tar.gz
-var FLUTTER_DIST_MIRROR = "https://storage.googleapis.com/flutter_infra/releases/{{.Channel}}/{{.OS}}/flutter_{{.OS}}_v{{.Version}}-{{.Channel}}.{{.Extension}}"
+var FLUTTER_DIST_MIRROR = "https://storage.googleapis.com/flutter_infra/releases/{{.Channel}}/{{.OS}}/flutter_{{.OS}}_{{.Version}}-{{.Channel}}.{{.Extension}}"
 
 type FlutterBuildTool struct {
 	BuildTool
@@ -66,11 +67,12 @@ func (bt FlutterBuildTool) DownloadUrl() string {
 		channel,
 		opsys,
 		arch,
-		version,
+		downloadUrlVersion(version),
 		extension,
 	}
+	mirror := FLUTTER_DIST_MIRROR
 
-	url, _ := TemplateToString(FLUTTER_DIST_MIRROR, data)
+	url, _ := TemplateToString(mirror, data)
 
 	return url
 }
@@ -112,9 +114,9 @@ func (bt FlutterBuildTool) Install() error {
 	installDir := bt.InstallDir()
 
 	if _, err := os.Stat(flutterDir); err == nil {
-		log.Infof("Flutter v%s located in %s!", bt.Version(), flutterDir)
+		log.Infof("Flutter %s located in %s!", downloadUrlVersion(bt.Version()), flutterDir)
 	} else {
-		log.Infof("Will install Flutter v%s into %s", bt.Version(), flutterDir)
+		log.Infof("Will install Flutter %s into %s", downloadUrlVersion(bt.Version()), flutterDir)
 		downloadUrl := bt.DownloadUrl()
 
 		log.Infof("Downloading Flutter from URL %s...", downloadUrl)
@@ -133,4 +135,31 @@ func (bt FlutterBuildTool) Install() error {
 	}
 
 	return nil
+}
+
+// Starting with flutter 1.17 the version format changed.
+// Adding support for pre version 1.17 with "v" and keep support for no "v"
+// - Pre 1.17 version =>  vx.xx.x or vx.xx.x+hotfix.y
+//   https://storage.googleapis.com/.../flutter_windows_v1.12.13+hotfix.9-stable.zip
+// - 1.17 (and greater?) => 1.17.0 (no "v" in download URL)
+//   https://storage.googleapis.com/.../flutter_windows_1.17.0-stable.zip)
+//
+// Also, yb tacks on a v for customers when we build the URL.
+// This function will be backaward compatible (tack on "v"), it will support pre 1.17
+// version with a "v", and support 1.17 and greater
+//
+func downloadUrlVersion(version string) string {
+	version_1_17_0 := "v1.17.0"
+	compVersion := version
+
+	// Semver package requires the version to start with "v"
+	if !strings.HasPrefix(compVersion, "v") {
+		compVersion = fmt.Sprintf("v%s", version)
+	}
+
+	if semver.Compare(compVersion, version_1_17_0) < 0 {
+		version = compVersion
+	}
+
+	return version
 }

--- a/buildpacks/flutter_test.go
+++ b/buildpacks/flutter_test.go
@@ -24,6 +24,10 @@ func Test_downloadUrlVersion(t *testing.T) {
 			want: "2.0.0",
 		},
 		{
+			in:   "v2.0.0",
+			want: "2.0.0",
+		},
+		{
 			in:   "v1.12.13+hotfix.8",
 			want: "v1.12.13+hotfix.8",
 		},

--- a/buildpacks/flutter_test.go
+++ b/buildpacks/flutter_test.go
@@ -1,0 +1,50 @@
+package buildpacks
+
+import (
+	"testing"
+)
+
+// Test_downloadUrlVersion tests the different version formats for downloading
+// flutter
+func Test_downloadUrlVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{
+			in:   "1.17.0",
+			want: "1.17.0",
+		},
+		{
+			in:   "1.18.0",
+			want: "1.18.0",
+		},
+		{
+			in:   "2.0.0",
+			want: "2.0.0",
+		},
+		{
+			in:   "v1.12.13+hotfix.8",
+			want: "v1.12.13+hotfix.8",
+		},
+		{
+			in:   "1.12.13+hotfix.8",
+			want: "v1.12.13+hotfix.8",
+		},
+		{
+			in:   "v1.12.0",
+			want: "v1.12.0",
+		},
+		{
+			in:   "1.12.0",
+			want: "v1.12.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := downloadUrlVersion(tt.in); got != tt.want {
+				t.Errorf("downloadUrlVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/waigani/diffparser v0.0.0-20190828052634-7391f219313d // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708
+	golang.org/x/mod v0.2.0
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49N
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 h1:pXVtWnwHkrWD9ru3sDxY/qFK/bfc0egRovX91EjWjf4=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -226,6 +227,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
+golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -279,6 +282,9 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=


### PR DESCRIPTION
Starting with flutter 1.17 the version format changed.
Adding support for pre version 1.17 with "v" and keep support for no "v"
* Pre 1.17 version =>  vx.xx.x or vx.xx.x+hotfix.y
   https://storage.googleapis.com/.../flutter_windows_v1.12.13+hotfix.9-stable.zip
* 1.17 (and greater?) => 1.17.0 (no "v" in download URL)
   https://storage.googleapis.com/.../flutter_windows_1.17.0-stable.zip)

Also, yb tacks on a v for customers when we build the URL.
This function will be backward compatible (tack on "v"), it will support pre 1.17
version with a "v", and support 1.17 and greater


clubhouse: https://app.clubhouse.io/yourbaseio/story/1422/support-new-flutter-1-17-0
