### PR TITLE
New runtime doesn't support prefixing every command

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -81,6 +81,7 @@ func (b *BuildCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{})
 	buildFlags := workspace.BuildFlags{
 		HostOnly:   b.NoContainer,
 		CleanBuild: b.CleanBuild,
+		ExecPrefix: b.ExecPrefix,
 	}
 	stepTimers, buildError := targetPackage.BuildTarget(buildTargetName, buildFlags)
 

--- a/plumbing/util.go
+++ b/plumbing/util.go
@@ -289,6 +289,17 @@ func DecompressBuffer(b *bytes.Buffer) error {
 	return nil
 }
 
+// Returns two empty strings and false if env isn't formed as "something=.*"
+// Or else return env name, value and true
+func SaneEnvironmentVar(env string) (name, value string, sane bool) {
+	s := strings.SplitN(env, "=", 2)
+	if sane = (len(s) == 2); sane {
+		name = s[0]
+		value = s[1]
+	}
+	return
+}
+
 func CloneRepository(remote GitRemote, inMem bool, basePath string) (rep *git.Repository, err error) {
 	if remote.Branch == "" {
 		return nil, fmt.Errorf("No branch defined to clone repo %v", remote.Url)

--- a/workspace/build_manifest.go
+++ b/workspace/build_manifest.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/yourbase/narwhal"
+	"github.com/yourbase/yb/plumbing"
 	"github.com/yourbase/yb/plumbing/log"
 	"github.com/yourbase/yb/runtime"
 )
@@ -61,8 +62,7 @@ func (e *ExecPhase) EnvironmentVariables(envName string, data runtime.RuntimeEnv
 
 	for _, property := range e.Environment["default"] {
 
-		s := strings.SplitN(property, "=", 2)
-		if len(s) == 2 {
+		if _, _, ok := plumbing.SaneEnvironmentVar(property); ok {
 			interpolated, err := TemplateToString(property, data)
 			if err == nil {
 				result = append(result, interpolated)
@@ -78,8 +78,7 @@ func (e *ExecPhase) EnvironmentVariables(envName string, data runtime.RuntimeEnv
 
 	if envName != "default" {
 		for _, property := range e.Environment[envName] {
-			s := strings.SplitN(property, "=", 2)
-			if len(s) == 2 {
+			if _, _, ok := plumbing.SaneEnvironmentVar(property); ok {
 				result = append(result, property)
 			}
 		}

--- a/workspace/build_target.go
+++ b/workspace/build_target.go
@@ -180,8 +180,8 @@ func (bt BuildTarget) Build(runtimeCtx *runtime.Runtime, flags BuildFlags, packa
 	for _, cmdString := range bt.Commands {
 		var stepError error
 
-		if len(flags.ExecPrefix) > 0 {
-			cmdString = fmt.Sprintf("%s %s", flags.ExecPrefix, cmdString)
+		if flags.ExecPrefix != "" {
+			cmdString = flags.ExecPrefix + " " + cmdString
 		}
 
 		stepStartTime := time.Now()

--- a/workspace/build_target.go
+++ b/workspace/build_target.go
@@ -156,10 +156,10 @@ func (bt BuildTarget) Build(runtimeCtx *runtime.Runtime, flags BuildFlags, packa
 
 	// Do this after the containers are up
 	for _, envString := range bt.EnvironmentVariables(runtimeCtx.EnvironmentData()) {
-		parts := strings.Split(envString, "=")
+		parts := strings.SplitN(envString, "=", 2)
 		key := parts[0]
 		value := ""
-		if len(parts) > 1 {
+		if len(parts) == 2 {
 			value = parts[1]
 		} else {
 			log.Warnf("'%s' doesn't look like an environment variable", envString)
@@ -179,6 +179,10 @@ func (bt BuildTarget) Build(runtimeCtx *runtime.Runtime, flags BuildFlags, packa
 
 	for _, cmdString := range bt.Commands {
 		var stepError error
+
+		if len(flags.ExecPrefix) > 0 {
+			cmdString = fmt.Sprintf("%s %s", flags.ExecPrefix, cmdString)
+		}
 
 		stepStartTime := time.Now()
 		p := runtime.Process{

--- a/workspace/package.go
+++ b/workspace/package.go
@@ -20,6 +20,7 @@ import (
 type BuildFlags struct {
 	HostOnly   bool
 	CleanBuild bool
+	ExecPrefix string
 }
 
 type Package struct {
@@ -211,7 +212,6 @@ func (p Package) ExecutionRuntime(environment string) (*runtime.Runtime, error) 
 	execContainer.Command = "/usr/bin/tail -f /dev/null"
 	execContainer.Label = "exec"
 	execContainer.Ports = portMappings
-
 
 	// Add package to mounts @ /workspace
 	sourceMapDir := "/workspace"


### PR DESCRIPTION
`yb build -exec-prefix <something>` isn't working anymore. This tries to fix it.