### PR TITLE
Creates full directory structure for a "build" workpsace directory

### DIFF
--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -118,7 +118,7 @@ func (w Workspace) BuildRoot() string {
 	buildRoot := filepath.Join(w.Path, buildDir)
 
 	if _, err := os.Stat(buildRoot); os.IsNotExist(err) {
-		if err := os.Mkdir(buildRoot, 0700); err != nil {
+		if err := os.MkdirAll(buildRoot, 0700); err != nil {
 			log.Warnf("Unable to create build dir in workspace: %v\n", err)
 		}
 	}


### PR DESCRIPTION
This copes with a situation where the user decided to
`rm -r $HOME/.yourbase/workspaces/*`
