### PR TITLE
Adds a GoReleaser buildpack

### DIFF
--- a/buildpacks/anaconda.go
+++ b/buildpacks/anaconda.go
@@ -7,17 +7,15 @@ import (
 
 	"github.com/yourbase/yb/plumbing/log"
 	"github.com/yourbase/yb/runtime"
-	. "github.com/yourbase/yb/types"
 )
 
 type AnacondaBuildTool struct {
-	BuildTool
 	version         string
 	spec            BuildToolSpec
 	pyCompatibleNum int
 }
 
-var ANACONDA_DIST_MIRROR = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
+const anacondaDistMirrorTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
 
 func NewAnaconda2BuildTool(toolSpec BuildToolSpec) AnacondaBuildTool {
 	tool := AnacondaBuildTool{
@@ -43,7 +41,7 @@ func (bt AnacondaBuildTool) Version() string {
 	return bt.version
 }
 
-func (bt AnacondaBuildTool) Install(ctx context.Context) (error, string) {
+func (bt AnacondaBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	anacondaDir := filepath.Join(t.ToolsDir(ctx), "miniconda", "miniconda-"+bt.Version())
@@ -51,34 +49,37 @@ func (bt AnacondaBuildTool) Install(ctx context.Context) (error, string) {
 
 	if t.PathExists(ctx, anacondaDir) {
 		log.Infof("Anaconda installed in %s", anacondaDir)
-	} else {
-		log.Infof("Installing anaconda")
+		return anacondaDir, nil
+	}
+	log.Infof("Installing anaconda")
 
-		downloadUrl := bt.DownloadUrl()
-
-		log.Infof("Downloading Miniconda from URL %s...", downloadUrl)
-		localFile, err := t.DownloadFile(ctx, downloadUrl)
-		if err != nil {
-			log.Errorf("Unable to download: %v\n", err)
-			return err, ""
-		}
-		for _, cmd := range []string{
-			fmt.Sprintf("chmod +x %s", localFile),
-			fmt.Sprintf("bash %s -b -p %s", localFile, anacondaDir),
-		} {
-			log.Infof("Running: '%v' ", cmd)
-			t.Run(ctx, runtime.Process{
-				Command:   cmd,
-				Directory: setupDir,
-			})
-		}
-
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
 	}
 
-	return nil, anacondaDir
+	log.Infof("Downloading Miniconda from URL %s...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v\n", err)
+		return "", err
+	}
+	for _, cmd := range []string{
+		fmt.Sprintf("chmod +x %s", localFile),
+		fmt.Sprintf("bash %s -b -p %s", localFile, anacondaDir),
+	} {
+		log.Infof("Running: '%v' ", cmd)
+		t.Run(ctx, runtime.Process{
+			Command:   cmd,
+			Directory: setupDir,
+		})
+	}
+
+	return anacondaDir, nil
 }
 
-func (bt AnacondaBuildTool) DownloadUrl() string {
+func (bt AnacondaBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	opsys := OS()
 	arch := Arch()
 	extension := "sh"
@@ -119,9 +120,9 @@ func (bt AnacondaBuildTool) DownloadUrl() string {
 		extension,
 	}
 
-	url, _ := TemplateToString(ANACONDA_DIST_MIRROR, data)
+	url, err := TemplateToString(anacondaDistMirrorTemplate, data)
 
-	return url
+	return url, err
 }
 
 func (bt AnacondaBuildTool) Setup(ctx context.Context, installDir string) error {

--- a/buildpacks/android_ndk.go
+++ b/buildpacks/android_ndk.go
@@ -5,13 +5,11 @@ import (
 	"path/filepath"
 
 	"github.com/yourbase/yb/plumbing/log"
-	. "github.com/yourbase/yb/types"
 )
 
-var ANDROID_NDK_DIST_MIRROR = "https://dl.google.com/android/repository/android-ndk-{{.Version}}-{{.OS}}-{{.Arch}}.zip"
+const androidNDKDistMirrorTemplate = "https://dl.google.com/android/repository/android-ndk-{{.Version}}-{{.OS}}-{{.Arch}}.zip"
 
 type AndroidNdkBuildTool struct {
-	BuildTool
 	version string
 	spec    BuildToolSpec
 }
@@ -27,7 +25,7 @@ func NewAndroidNdkBuildTool(toolSpec BuildToolSpec) AndroidNdkBuildTool {
 	return tool
 }
 
-func (bt AndroidNdkBuildTool) DownloadUrl() string {
+func (bt AndroidNdkBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	opsys := OS()
 	arch := Arch()
 	extension := "zip"
@@ -50,9 +48,9 @@ func (bt AndroidNdkBuildTool) DownloadUrl() string {
 		extension,
 	}
 
-	url, _ := TemplateToString(ANDROID_NDK_DIST_MIRROR, data)
+	url, err := TemplateToString(androidNDKDistMirrorTemplate, data)
 
-	return url
+	return url, err
 }
 
 func (bt AndroidNdkBuildTool) Version() string {
@@ -68,7 +66,7 @@ func (bt AndroidNdkBuildTool) Setup(ctx context.Context, ndkDir string) error {
 	return nil
 }
 
-func (bt AndroidNdkBuildTool) Install(ctx context.Context) (error, string) {
+func (bt AndroidNdkBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	installDir := filepath.Join(t.ToolsDir(ctx), "android-ndk")
@@ -76,23 +74,26 @@ func (bt AndroidNdkBuildTool) Install(ctx context.Context) (error, string) {
 
 	if t.PathExists(ctx, ndkDir) {
 		log.Infof("Android NDK v%s located in %s!", bt.Version(), ndkDir)
-	} else {
-		log.Infof("Will install Android NDK v%s into %s", bt.Version(), ndkDir)
-		downloadUrl := bt.DownloadUrl()
-
-		log.Infof("Downloading Android NDK v%s from URL %s...", bt.Version(), downloadUrl)
-		localFile, err := t.DownloadFile(ctx, downloadUrl)
-		if err != nil {
-			log.Errorf("Unable to download: %v", err)
-			return err, ""
-		}
-		err = t.Unarchive(ctx, localFile, installDir)
-		if err != nil {
-			log.Errorf("Unable to decompress: %v", err)
-			return err, ""
-		}
-
+		return ndkDir, nil
+	}
+	log.Infof("Will install Android NDK v%s into %s", bt.Version(), ndkDir)
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
 	}
 
-	return nil, ndkDir
+	log.Infof("Downloading Android NDK v%s from URL %s...", bt.Version(), downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v", err)
+		return "", err
+	}
+	err = t.Unarchive(ctx, localFile, installDir)
+	if err != nil {
+		log.Errorf("Unable to decompress: %v", err)
+		return "", err
+	}
+
+	return ndkDir, nil
 }

--- a/buildpacks/ant.go
+++ b/buildpacks/ant.go
@@ -7,14 +7,12 @@ import (
 	"strings"
 
 	"github.com/yourbase/yb/plumbing/log"
-	. "github.com/yourbase/yb/types"
 )
 
 //http://apache.mirrors.lucidnetworks.net//ant/binaries/apache-ant-1.10.6-bin.tar.gz
-var ANT_DIST_MIRROR = "http://apache.mirrors.lucidnetworks.net/ant/binaries/apache-ant-{{.Version}}-bin.zip"
+const antDistMirrorTemplate = "http://apache.mirrors.lucidnetworks.net/ant/binaries/apache-ant-{{.Version}}-bin.zip"
 
 type AntBuildTool struct {
-	BuildTool
 	version string
 	spec    BuildToolSpec
 }
@@ -33,16 +31,16 @@ func (bt AntBuildTool) ArchiveFile() string {
 	return fmt.Sprintf("apache-ant-%s-bin.zip", bt.Version())
 }
 
-func (bt AntBuildTool) DownloadUrl() string {
+func (bt AntBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	data := struct {
 		Version string
 	}{
 		bt.Version(),
 	}
 
-	url, _ := TemplateToString(ANT_DIST_MIRROR, data)
+	url, err := TemplateToString(antDistMirrorTemplate, data)
 
-	return url
+	return url, err
 }
 
 func (bt AntBuildTool) MajorVersion() string {
@@ -63,7 +61,7 @@ func (bt AntBuildTool) Setup(ctx context.Context, antDir string) error {
 }
 
 // TODO, generalize downloader
-func (bt AntBuildTool) Install(ctx context.Context) (error, string) {
+func (bt AntBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	installDir := filepath.Join(t.ToolsDir(ctx), "ant")
@@ -71,23 +69,27 @@ func (bt AntBuildTool) Install(ctx context.Context) (error, string) {
 
 	if t.PathExists(ctx, antDir) {
 		log.Infof("Ant v%s located in %s!", bt.Version(), antDir)
-	} else {
-		log.Infof("Will install Ant v%s into %s", bt.Version(), antDir)
-		downloadUrl := bt.DownloadUrl()
-
-		log.Infof("Downloading Ant from URL %s...", downloadUrl)
-		localFile, err := t.DownloadFile(ctx, downloadUrl)
-		if err != nil {
-			log.Errorf("Unable to download: %v", err)
-			return err, ""
-		}
-		err = t.Unarchive(ctx, localFile, installDir)
-		if err != nil {
-			log.Errorf("Unable to decompress: %v", err)
-			return err, ""
-		}
-
+		return antDir, nil
 	}
 
-	return nil, antDir
+	log.Infof("Will install Ant v%s into %s", bt.Version(), antDir)
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
+	}
+
+	log.Infof("Downloading Ant from URL %s...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v", err)
+		return "", err
+	}
+	err = t.Unarchive(ctx, localFile, installDir)
+	if err != nil {
+		log.Errorf("Unable to decompress: %v", err)
+		return "", err
+	}
+
+	return antDir, nil
 }

--- a/buildpacks/flutter.go
+++ b/buildpacks/flutter.go
@@ -9,14 +9,12 @@ import (
 	"golang.org/x/mod/semver"
 
 	"github.com/yourbase/yb/plumbing/log"
-	. "github.com/yourbase/yb/types"
 )
 
 // https://archive.apache.org/dist/flutter/flutter-3/3.3.3/binaries/apache-flutter-3.3.3-bin.tar.gz
-var FLUTTER_DIST_MIRROR = "https://storage.googleapis.com/flutter_infra/releases/{{.Channel}}/{{.OS}}/flutter_{{.OS}}_{{.Version}}-{{.Channel}}.{{.Extension}}"
+const flutterDistMirrorTemplate = "https://storage.googleapis.com/flutter_infra/releases/{{.Channel}}/{{.OS}}/flutter_{{.OS}}_{{.Version}}-{{.Channel}}.{{.Extension}}"
 
 type FlutterBuildTool struct {
-	BuildTool
 	version string
 	spec    BuildToolSpec
 }
@@ -31,7 +29,7 @@ func NewFlutterBuildTool(spec BuildToolSpec) FlutterBuildTool {
 	return tool
 }
 
-func (bt FlutterBuildTool) DownloadUrl() string {
+func (bt FlutterBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	opsys := OS()
 	arch := Arch()
 	extension := "tar.xz"
@@ -65,12 +63,12 @@ func (bt FlutterBuildTool) DownloadUrl() string {
 		channel,
 		opsys,
 		arch,
-		downloadUrlVersion(version),
+		downloadURLVersion(version),
 		extension,
 	}
-	url, _ := TemplateToString(FLUTTER_DIST_MIRROR, data)
+	url, err := TemplateToString(flutterDistMirrorTemplate, data)
 
-	return url
+	return url, err
 }
 
 // TODO: Add Channel method?
@@ -92,34 +90,36 @@ func (bt FlutterBuildTool) Setup(ctx context.Context, flutterDir string) error {
 	return nil
 }
 
-func (bt FlutterBuildTool) Install(ctx context.Context) (error, string) {
+func (bt FlutterBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	installDir := filepath.Join(t.ToolsDir(ctx), "flutter", "flutter-"+bt.Version())
 	flutterDir := filepath.Join(installDir, "flutter")
 
 	if t.PathExists(ctx, flutterDir) {
-		log.Infof("Flutter %s located in %s!", downloadUrlVersion(bt.Version()), flutterDir)
-	} else {
-		log.Infof("Will install Flutter %s into %s", downloadUrlVersion(bt.Version()), flutterDir)
-		downloadUrl := bt.DownloadUrl()
-
-		log.Infof("Downloading Flutter from URL %s...", downloadUrl)
-		localFile, err := t.DownloadFile(ctx, downloadUrl)
-		if err != nil {
-			log.Errorf("Unable to download: %v", err)
-			return err, ""
-		}
-		err = t.Unarchive(ctx, localFile, installDir)
-		if err != nil {
-			log.Errorf("Unable to decompress: %v", err)
-			return err, ""
-		}
-
-		//RemoveWritePermissionRecursively(installDir)
+		log.Infof("Flutter %s located in %s!", downloadURLVersion(bt.Version()), flutterDir)
+		return flutterDir, nil
+	}
+	log.Infof("Will install Flutter %s into %s", downloadURLVersion(bt.Version()), flutterDir)
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
 	}
 
-	return nil, flutterDir
+	log.Infof("Downloading Flutter from URL %s...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v", err)
+		return "", err
+	}
+	err = t.Unarchive(ctx, localFile, installDir)
+	if err != nil {
+		log.Errorf("Unable to decompress: %v", err)
+		return "", err
+	}
+
+	return flutterDir, nil
 }
 
 // Starting with flutter 1.17 the version format changed.
@@ -136,7 +136,7 @@ func (bt FlutterBuildTool) Install(ctx context.Context) (error, string) {
 // Note: We are predicting the future since they could require a "v" again if 1.17.0
 // was a mistake
 //
-func downloadUrlVersion(version string) string {
+func downloadURLVersion(version string) string {
 	version_1_17_0 := "v1.17.0"
 	compVersion := version
 

--- a/buildpacks/flutter_test.go
+++ b/buildpacks/flutter_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-// Test_downloadUrlVersion tests the different version formats for downloading
+// Test_downloadURLVersion tests the different version formats for downloading
 // flutter
-func Test_downloadUrlVersion(t *testing.T) {
+func Test_downloadURLVersion(t *testing.T) {
 	tests := []struct {
 		in   string
 		want string
@@ -46,8 +46,8 @@ func Test_downloadUrlVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			if got := downloadUrlVersion(tt.in); got != tt.want {
-				t.Errorf("downloadUrlVersion() = %v, want %v", got, tt.want)
+			if got := downloadURLVersion(tt.in); got != tt.want {
+				t.Errorf("downloadURLVersion() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/buildpacks/glide.go
+++ b/buildpacks/glide.go
@@ -6,13 +6,11 @@ import (
 	"path/filepath"
 
 	"github.com/yourbase/yb/plumbing/log"
-	. "github.com/yourbase/yb/types"
 )
 
-var GLIDE_DIST_MIRROR = "https://github.com/Masterminds/glide/releases/download/v{{.Version}}/glide-v{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz"
+const glideDistMirrorTemplate = "https://github.com/Masterminds/glide/releases/download/v{{.Version}}/glide-v{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz"
 
 type GlideBuildTool struct {
-	BuildTool
 	version string
 	spec    BuildToolSpec
 }
@@ -46,44 +44,52 @@ func (bt GlideBuildTool) Setup(ctx context.Context, glideDir string) error {
 	return nil
 }
 
-func (bt GlideBuildTool) Install(ctx context.Context) (error, string) {
+func (bt GlideBuildTool) DownloadURL(ctx context.Context) (string, error) {
+	params := struct {
+		OS      string
+		Arch    string
+		Version string
+	}{
+		OS:      OS(),
+		Arch:    Arch(),
+		Version: bt.Version(),
+	}
+
+	downloadURL, err := TemplateToString(glideDistMirrorTemplate, params)
+	return downloadURL, err
+}
+
+func (bt GlideBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	glideDir := filepath.Join(t.ToolsDir(ctx), "glide-"+bt.Version())
 
 	if t.PathExists(ctx, glideDir) {
 		log.Infof("Glide v%s located in %s!", bt.Version(), glideDir)
-	} else {
-		log.Infof("Will install Glide v%s into %s", bt.Version(), glideDir)
-		params := DownloadParameters{
-			OS:      OS(),
-			Arch:    Arch(),
-			Version: bt.Version(),
-		}
-
-		downloadUrl, err := TemplateToString(GLIDE_DIST_MIRROR, params)
-		if err != nil {
-			log.Errorf("Unable to generate download URL: %v", err)
-			return err, ""
-		}
-
-		log.Infof("Downloading from URL %s ...", downloadUrl)
-		localFile, err := t.DownloadFile(ctx, downloadUrl)
-		if err != nil {
-			log.Errorf("Unable to download: %v", err)
-			return err, ""
-		}
-
-		t.MkdirAsNeeded(ctx, glideDir)
-		log.Infof("Extracting glide %s to %s...", bt.Version(), glideDir)
-		err = t.Unarchive(ctx, localFile, glideDir)
-		if err != nil {
-			log.Errorf("Unable to decompress: %v", err)
-			return err, ""
-		}
-
+		return glideDir, nil
+	}
+	log.Infof("Will install Glide v%s into %s", bt.Version(), glideDir)
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
 	}
 
-	return nil, glideDir
+	log.Infof("Downloading from URL %s ...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v", err)
+		return "", err
+	}
+
+	t.MkdirAsNeeded(ctx, glideDir)
+	log.Infof("Extracting glide %s to %s...", bt.Version(), glideDir)
+	err = t.Unarchive(ctx, localFile, glideDir)
+	if err != nil {
+		log.Errorf("Unable to decompress: %v", err)
+		return "", err
+	}
+
+	return glideDir, nil
 
 }

--- a/buildpacks/golang.go
+++ b/buildpacks/golang.go
@@ -3,11 +3,11 @@ package buildpacks
 import (
 	"context"
 	"fmt"
-	"github.com/yourbase/yb/runtime"
 	"path/filepath"
 	"strings"
 
 	"github.com/yourbase/yb/plumbing/log"
+	"github.com/yourbase/yb/runtime"
 	. "github.com/yourbase/yb/types"
 )
 

--- a/buildpacks/goreleaser.go
+++ b/buildpacks/goreleaser.go
@@ -1,0 +1,96 @@
+package buildpacks
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/yourbase/yb/plumbing/log"
+	"github.com/yourbase/yb/runtime"
+	. "github.com/yourbase/yb/types"
+)
+
+// TODO add yourbase/release-test testing facilities
+
+var GORELEASE_DIST_TEMPLATE_URL = "https://github.com/goreleaser/goreleaser/releases/download/%s/%s"
+
+type GoReleaserBuildTool struct {
+	BuildTool
+	version string
+	spec    BuildToolSpec
+}
+
+func NewGoReleaserBuildTool(toolSpec BuildToolSpec) GoReleaserBuildTool {
+	tool := GoReleaserBuildTool{
+		version: toolSpec.Version,
+		spec:    toolSpec,
+	}
+
+	return tool
+}
+
+func (bt GoReleaserBuildTool) ArchiveFile() string {
+	operatingSystem := bt.spec.InstallTarget.OS()
+	arch := bt.spec.InstallTarget.Architecture()
+	os := "Linux"
+	architecture := "x86_64"
+	ext := "tar.gz"
+
+	if operatingSystem == runtime.Darwin {
+		os = "Darwin"
+	} else if operatingSystem == runtime.Windows {
+		os = "Windows"
+		ext = "zip"
+	}
+
+	// TODO support arm64, armv6
+	if arch != runtime.Amd64 {
+		architecture = "i386"
+	}
+
+	return fmt.Sprintf("goreleaser_%s_%s.%s", os, architecture, ext)
+}
+
+func (bt GoReleaserBuildTool) DonwloadUrl() string {
+	return fmt.Sprintf(GORELEASE_DIST_TEMPLATE_URL, bt.Version(), bt.ArchiveFile())
+}
+
+func (bt GoReleaserBuildTool) Version() string {
+	return bt.version
+}
+
+func (bt GoReleaserBuildTool) Install(ctx context.Context) (error, string) {
+	t := bt.spec.InstallTarget
+
+	installDir := filepath.Join(t.ToolsDir(ctx), "goreleaser", bt.Version())
+
+	if t.PathExists(ctx, installDir) {
+		log.Infof("GoReleaser v%s located in %s!", bt.Version(), installDir)
+	} else {
+		log.Infof("Will install GoReleaser v%s into %s", bt.Version(), installDir)
+
+		downloadUrl := bt.DonwloadUrl()
+		log.Infof("Downloading from URL %s ...", downloadUrl)
+		localFile, err := t.DownloadFile(ctx, downloadUrl)
+		if err != nil {
+			log.Errorf("Unable to download: %v", err)
+			return err, ""
+		}
+
+		err = t.Unarchive(ctx, localFile, installDir)
+		if err != nil {
+			log.Errorf("Unable to decompress: %v", err)
+			return err, ""
+		}
+	}
+
+	return nil, installDir
+}
+
+func (bt GoReleaserBuildTool) Setup(ctx context.Context, installDir string) error {
+	t := bt.spec.InstallTarget
+
+	t.PrependToPath(ctx, installDir)
+
+	return nil
+}

--- a/buildpacks/heroku.go
+++ b/buildpacks/heroku.go
@@ -7,14 +7,12 @@ import (
 	"strings"
 
 	"github.com/yourbase/yb/plumbing/log"
-	. "github.com/yourbase/yb/types"
 )
 
 //https://archive.apache.org/dist/heroku/heroku-3/3.3.3/binaries/apache-heroku-3.3.3-bin.tar.gz
-var HEROKU_DIST_MIRROR = "https://cli-assets.heroku.com/heroku-{{.OS}}-{{.Arch}}.tar.gz"
+const herokuDistMirrorTemplate = "https://cli-assets.heroku.com/heroku-{{.OS}}-{{.Arch}}.tar.gz"
 
 type HerokuBuildTool struct {
-	BuildTool
 	version string
 	spec    BuildToolSpec
 }
@@ -32,7 +30,7 @@ func (bt HerokuBuildTool) ArchiveFile() string {
 	return fmt.Sprintf("apache-heroku-%s-bin.tar.gz", bt.Version())
 }
 
-func (bt HerokuBuildTool) DownloadUrl() string {
+func (bt HerokuBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	opsys := OS()
 	arch := Arch()
 
@@ -48,9 +46,8 @@ func (bt HerokuBuildTool) DownloadUrl() string {
 		arch,
 	}
 
-	url, _ := TemplateToString(HEROKU_DIST_MIRROR, data)
-
-	return url
+	url, err := TemplateToString(herokuDistMirrorTemplate, data)
+	return url, err
 }
 
 func (bt HerokuBuildTool) MajorVersion() string {
@@ -70,30 +67,33 @@ func (bt HerokuBuildTool) Setup(ctx context.Context, herokuDir string) error {
 	return nil
 }
 
-func (bt HerokuBuildTool) Install(ctx context.Context) (error, string) {
+func (bt HerokuBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	herokuDir := filepath.Join(t.ToolsDir(ctx), "heroku", bt.Version())
 
 	if t.PathExists(ctx, herokuDir) {
 		log.Infof("Heroku v%s located in %s!", bt.Version(), herokuDir)
-	} else {
-		log.Infof("Will install Heroku v%s into %s", bt.Version(), herokuDir)
-		downloadUrl := bt.DownloadUrl()
-
-		log.Infof("Downloading Heroku from URL %s...", downloadUrl)
-		localFile, err := t.DownloadFile(ctx, downloadUrl)
-		if err != nil {
-			log.Errorf("Unable to download: %v", err)
-			return err, ""
-		}
-		err = t.Unarchive(ctx, localFile, herokuDir)
-		if err != nil {
-			log.Errorf("Unable to decompress: %v", err)
-			return err, ""
-		}
-
+		return herokuDir, nil
+	}
+	log.Infof("Will install Heroku v%s into %s", bt.Version(), herokuDir)
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
 	}
 
-	return nil, herokuDir
+	log.Infof("Downloading Heroku from URL %s...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v", err)
+		return "", err
+	}
+	err = t.Unarchive(ctx, localFile, herokuDir)
+	if err != nil {
+		log.Errorf("Unable to decompress: %v", err)
+		return "", err
+	}
+
+	return herokuDir, err
 }

--- a/buildpacks/homebrew.go
+++ b/buildpacks/homebrew.go
@@ -12,12 +12,10 @@ import (
 	"github.com/matishsiao/goInfo"
 	"github.com/yourbase/yb/plumbing/log"
 	"github.com/yourbase/yb/runtime"
-	. "github.com/yourbase/yb/types"
 	"gopkg.in/src-d/go-git.v4"
 )
 
 type HomebrewBuildTool struct {
-	BuildTool
 	version   string
 	spec      BuildToolSpec
 	pkgName   string
@@ -116,7 +114,7 @@ func (bt HomebrewBuildTool) PackageVersionString() string {
 
 	return fmt.Sprintf("%s%s", bt.pkgName, pkgVersion)
 }
-func (bt HomebrewBuildTool) Install(ctx context.Context) (error, string) {
+func (bt HomebrewBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	installDir := filepath.Join(t.ToolsDir(ctx), "homebrew")
@@ -140,7 +138,7 @@ func (bt HomebrewBuildTool) Install(ctx context.Context) (error, string) {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Unable to install Homebrew: %v", err), ""
+		return "", fmt.Errorf("Unable to install Homebrew: %v", err)
 	}
 
 	if bt.IsPackage() {
@@ -150,12 +148,12 @@ func (bt HomebrewBuildTool) Install(ctx context.Context) (error, string) {
 			log.Infof("Installing package %s", bt.PackageVersionString())
 			err = bt.InstallPackage(ctx, brewDir)
 			if err != nil {
-				return err, ""
+				return "", err
 			}
 		}
 	}
 
-	return nil, brewDir
+	return brewDir, nil
 }
 
 func (bt HomebrewBuildTool) InstallPackage(ctx context.Context, brewDir string) error {
@@ -274,6 +272,11 @@ func (bt HomebrewBuildTool) Setup(ctx context.Context, brewDir string) error {
 		t.SetEnv("LD_LIBRARY_PATH", brewLibDir)
 	}
 	return nil
+}
+
+func (bt HomebrewBuildTool) DownloadURL(ctx context.Context) (string, error) {
+	// No-op
+	return "", nil
 }
 
 func (bt HomebrewBuildTool) InstallPlatformDependencies() error {

--- a/buildpacks/openjdk_test.go
+++ b/buildpacks/openjdk_test.go
@@ -1,6 +1,9 @@
 package buildpacks
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestOpenJDKUrlGeneration(t *testing.T) {
 	for _, data := range []struct {
@@ -30,7 +33,10 @@ func TestOpenJDKUrlGeneration(t *testing.T) {
 	} {
 		bt := NewJavaBuildTool(BuildToolSpec{Tool: "java", Version: data.version, PackageDir: "/opt/tools/java"})
 
-		url := bt.DownloadUrl()
+		url, err := bt.DownloadURL(context.Background())
+		if err != nil {
+			t.Fatalf("Template wasn't applied correctly: %v", err)
+		}
 		wanted := data.url
 
 		if url != wanted {

--- a/buildpacks/protoc.go
+++ b/buildpacks/protoc.go
@@ -6,14 +6,12 @@ import (
 	"strings"
 
 	"github.com/yourbase/yb/plumbing/log"
-	. "github.com/yourbase/yb/types"
 )
 
 // https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
-const ProtocDistMirror = "https://github.com/google/protobuf/releases/download/v{{.Version}}/protoc-{{.Version}}-{{.OS}}-x86_64.{{.Extension}}"
+const protocDistMirror = "https://github.com/google/protobuf/releases/download/v{{.Version}}/protoc-{{.Version}}-{{.OS}}-x86_64.{{.Extension}}"
 
 type ProtocBuildTool struct {
-	BuildTool
 	version string
 	spec    BuildToolSpec
 }
@@ -28,7 +26,7 @@ func NewProtocBuildTool(spec BuildToolSpec) ProtocBuildTool {
 	return tool
 }
 
-func (bt ProtocBuildTool) DownloadUrl() string {
+func (bt ProtocBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	opsys := OS()
 	arch := Arch()
 	extension := "zip"
@@ -55,9 +53,8 @@ func (bt ProtocBuildTool) DownloadUrl() string {
 		extension,
 	}
 
-	url, _ := TemplateToString(ProtocDistMirror, data)
-
-	return url
+	url, err := TemplateToString(protocDistMirror, data)
+	return url, err
 }
 
 func (bt ProtocBuildTool) MajorVersion() string {
@@ -77,7 +74,7 @@ func (bt ProtocBuildTool) Setup(ctx context.Context, protocDir string) error {
 	return nil
 }
 
-func (bt ProtocBuildTool) Install(ctx context.Context) (error, string) {
+func (bt ProtocBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	installDir := filepath.Join(t.ToolsDir(ctx), "protoc")
@@ -85,22 +82,26 @@ func (bt ProtocBuildTool) Install(ctx context.Context) (error, string) {
 
 	if t.PathExists(ctx, protocDir) {
 		log.Infof("Protoc v%s located in %s!", bt.Version(), protocDir)
-		return nil, ""
+		return protocDir, nil
 	}
 	log.Infof("Will install Protoc v%s into %s", bt.Version(), protocDir)
-	downloadUrl := bt.DownloadUrl()
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
+	}
 
-	log.Infof("Downloading Protoc from URL %s...", downloadUrl)
-	localFile, err := t.DownloadFile(ctx, downloadUrl)
+	log.Infof("Downloading Protoc from URL %s...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
 	if err != nil {
 		log.Errorf("Unable to download: %v", err)
-		return err, ""
+		return "", err
 	}
 	err = t.Unarchive(ctx, localFile, installDir)
 	if err != nil {
 		log.Errorf("Unable to decompress: %v", err)
-		return err, ""
+		return "", err
 	}
 
-	return nil, protocDir
+	return protocDir, nil
 }

--- a/buildpacks/python.go
+++ b/buildpacks/python.go
@@ -7,20 +7,17 @@ import (
 
 	"github.com/yourbase/yb/plumbing/log"
 	"github.com/yourbase/yb/runtime"
-	. "github.com/yourbase/yb/types"
 )
 
-var (
+const (
 	anacondaToolVersion = "4.7.10"
+	anacondaURLTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
 )
 
 type PythonBuildTool struct {
-	BuildTool
 	version string
 	spec    BuildToolSpec
 }
-
-var anacondaURLTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
 
 func NewPythonBuildTool(toolSpec BuildToolSpec) PythonBuildTool {
 	tool := PythonBuildTool{
@@ -35,7 +32,7 @@ func (bt PythonBuildTool) Version() string {
 	return bt.version
 }
 
-func (bt PythonBuildTool) Install(ctx context.Context) (error, string) {
+func (bt PythonBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	anacondaDir := filepath.Join(t.ToolsDir(ctx), "miniconda3", "miniconda-"+anacondaToolVersion)
@@ -43,39 +40,42 @@ func (bt PythonBuildTool) Install(ctx context.Context) (error, string) {
 
 	if t.PathExists(ctx, anacondaDir) {
 		log.Infof("anaconda installed in %s", anacondaDir)
-	} else {
-		log.Infof("Installing anaconda")
+		return anacondaDir, nil
+	}
+	log.Infof("Installing anaconda")
 
-		downloadUrl := bt.DownloadUrl()
-
-		log.Infof("Downloading Miniconda from URL %s...", downloadUrl)
-		localFile, err := t.DownloadFile(ctx, downloadUrl)
-		if err != nil {
-			log.Errorf("Unable to download: %v", err)
-			return err, ""
-		}
-
-		// TODO: Windows
-		for _, cmd := range []string{
-			fmt.Sprintf("chmod +x %s", localFile),
-			fmt.Sprintf("bash %s -b -p %s", localFile, anacondaDir),
-		} {
-			log.Infof("Running: '%v' ", cmd)
-			p := runtime.Process{
-				Command:   cmd,
-				Directory: setupDir,
-			}
-			if err := t.Run(ctx, p); err != nil {
-				return fmt.Errorf("Couldn't install python: %v", err), ""
-			}
-		}
-
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
 	}
 
-	return nil, anacondaDir
+	log.Infof("Downloading Miniconda from URL %s...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v", err)
+		return "", err
+	}
+
+	// TODO: Windows
+	for _, cmd := range []string{
+		fmt.Sprintf("chmod +x %s", localFile),
+		fmt.Sprintf("bash %s -b -p %s", localFile, anacondaDir),
+	} {
+		log.Infof("Running: '%v' ", cmd)
+		p := runtime.Process{
+			Command:   cmd,
+			Directory: setupDir,
+		}
+		if err := t.Run(ctx, p); err != nil {
+			return "", fmt.Errorf("Couldn't install python: %v", err)
+		}
+	}
+
+	return anacondaDir, nil
 }
 
-func (bt PythonBuildTool) DownloadUrl() string {
+func (bt PythonBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	opsys := ""
 	arch := ""
 	extension := "sh"
@@ -114,9 +114,8 @@ func (bt PythonBuildTool) DownloadUrl() string {
 		extension,
 	}
 
-	url, _ := TemplateToString(anacondaURLTemplate, data)
-
-	return url
+	url, err := TemplateToString(anacondaURLTemplate, data)
+	return url, err
 }
 
 func (bt PythonBuildTool) Setup(ctx context.Context, condaDir string) error {

--- a/buildpacks/rlang.go
+++ b/buildpacks/rlang.go
@@ -8,13 +8,11 @@ import (
 
 	"github.com/yourbase/yb/plumbing/log"
 	"github.com/yourbase/yb/runtime"
-	. "github.com/yourbase/yb/types"
 )
 
-var RLANG_DIST_MIRROR = "https://cloud.r-project.org/src/base"
+const rlangDistMirrorTemplate = "https://cloud.r-project.org/src/base"
 
 type RLangBuildTool struct {
-	BuildTool
 	version string
 	spec    BuildToolSpec
 }
@@ -32,13 +30,13 @@ func (bt RLangBuildTool) ArchiveFile() string {
 	return fmt.Sprintf("R-%s.tar.gz", bt.Version())
 }
 
-func (bt RLangBuildTool) DownloadUrl() string {
+func (bt RLangBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	return fmt.Sprintf(
 		"%s/R-%s/%s",
-		RLANG_DIST_MIRROR,
+		rlangDistMirrorTemplate,
 		bt.MajorVersion(),
 		bt.ArchiveFile(),
-	)
+	), nil
 }
 
 func (bt RLangBuildTool) MajorVersion() string {
@@ -58,7 +56,7 @@ func (bt RLangBuildTool) Setup(ctx context.Context, rlangDir string) error {
 	return nil
 }
 
-func (bt RLangBuildTool) Install(ctx context.Context) (error, string) {
+func (bt RLangBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	installDir := filepath.Join(t.ToolsDir(ctx), "R")
@@ -66,41 +64,45 @@ func (bt RLangBuildTool) Install(ctx context.Context) (error, string) {
 
 	if t.PathExists(ctx, rlangDir) {
 		log.Infof("R v%s located in %s!", bt.Version(), rlangDir)
-	} else {
-		log.Infof("Will install R v%s into %s", bt.Version(), installDir)
-		downloadUrl := bt.DownloadUrl()
-
-		log.Infof("Downloading from URL %s ...", downloadUrl)
-		localFile, err := t.DownloadFile(ctx, downloadUrl)
-		if err != nil {
-			log.Errorf("Unable to download: %v", err)
-			return err, ""
-		}
-
-		tmpDir := filepath.Join(installDir, "src")
-		srcDir := filepath.Join(tmpDir, fmt.Sprintf("R-%s", bt.Version()))
-
-		if !t.PathExists(ctx, srcDir) {
-			err = t.Unarchive(ctx, localFile, tmpDir)
-			if err != nil {
-				log.Errorf("Unable to decompress: %v", err)
-				return err, ""
-			}
-		}
-
-		t.MkdirAsNeeded(ctx, rlangDir)
-		p := runtime.Process{
-			Command:   "./configure --with-x=no --prefix=" + rlangDir,
-			Directory: srcDir,
-		}
-		t.Run(ctx, p)
-
-		// TODO guarantee that we have 'make' installed
-		p.Command = "make"
-		t.Run(ctx, p)
-		p.Command = "make install"
-		t.Run(ctx, p)
+		return rlangDir, nil
+	}
+	log.Infof("Will install R v%s into %s", bt.Version(), installDir)
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
 	}
 
-	return nil, rlangDir
+	log.Infof("Downloading from URL %s ...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v", err)
+		return "", err
+	}
+
+	tmpDir := filepath.Join(installDir, "src")
+	srcDir := filepath.Join(tmpDir, fmt.Sprintf("R-%s", bt.Version()))
+
+	if !t.PathExists(ctx, srcDir) {
+		err = t.Unarchive(ctx, localFile, tmpDir)
+		if err != nil {
+			log.Errorf("Unable to decompress: %v", err)
+			return "", err
+		}
+	}
+
+	t.MkdirAsNeeded(ctx, rlangDir)
+	p := runtime.Process{
+		Command:   "./configure --with-x=no --prefix=" + rlangDir,
+		Directory: srcDir,
+	}
+	t.Run(ctx, p)
+
+	// TODO guarantee that we have 'make' installed
+	p.Command = "make"
+	t.Run(ctx, p)
+	p.Command = "make install"
+	t.Run(ctx, p)
+
+	return rlangDir, nil
 }

--- a/buildpacks/yarn.go
+++ b/buildpacks/yarn.go
@@ -6,11 +6,9 @@ import (
 	"path/filepath"
 
 	"github.com/yourbase/yb/plumbing/log"
-	. "github.com/yourbase/yb/types"
 )
 
 type YarnBuildTool struct {
-	BuildTool
 	version string
 	spec    BuildToolSpec
 }
@@ -28,7 +26,7 @@ func (bt YarnBuildTool) Version() string {
 	return bt.version
 }
 
-func (bt YarnBuildTool) DownloadUrl() string {
+func (bt YarnBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	urlTemplate := "https://github.com/yarnpkg/yarn/releases/download/v{{ .Version }}/yarn-v{{ .Version }}.tar.gz"
 	data := struct {
 		Version string
@@ -36,12 +34,11 @@ func (bt YarnBuildTool) DownloadUrl() string {
 		bt.Version(),
 	}
 
-	url, _ := TemplateToString(urlTemplate, data)
-
-	return url
+	url, err := TemplateToString(urlTemplate, data)
+	return url, err
 }
 
-func (bt YarnBuildTool) Install(ctx context.Context) (error, string) {
+func (bt YarnBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	installDir := filepath.Join(t.ToolsDir(ctx), "yarn")
@@ -49,21 +46,26 @@ func (bt YarnBuildTool) Install(ctx context.Context) (error, string) {
 
 	if t.PathExists(ctx, yarnDir) {
 		log.Infof("Yarn v%s located in %s!", bt.Version(), yarnDir)
-	} else {
-		log.Infof("Will install Yarn v%s into %s", bt.Version(), installDir)
-		downloadUrl := bt.DownloadUrl()
-		log.Infof("Downloading from URL %s...", downloadUrl)
-		localFile, err := t.DownloadFile(ctx, downloadUrl)
-		if err != nil {
-			return fmt.Errorf("Unable to download %s: %v", downloadUrl, err), ""
-		}
-
-		if err := t.Unarchive(ctx, localFile, installDir); err != nil {
-			return fmt.Errorf("Unable to decompress archive: %v", err), ""
-		}
+		return yarnDir, nil
+	}
+	log.Infof("Will install Yarn v%s into %s", bt.Version(), installDir)
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
 	}
 
-	return nil, yarnDir
+	log.Infof("Downloading from URL %s...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		return "", fmt.Errorf("Unable to download %s: %v", downloadURL, err)
+	}
+
+	if err := t.Unarchive(ctx, localFile, installDir); err != nil {
+		return "", fmt.Errorf("Unable to decompress archive: %v", err)
+	}
+
+	return yarnDir, nil
 }
 
 func (bt YarnBuildTool) Setup(ctx context.Context, yarnDir string) error {

--- a/types/types.go
+++ b/types/types.go
@@ -36,7 +36,8 @@ type WorktreeSave struct {
 }
 
 type BuildTool interface {
-	Install(ctx context.Context) (error, string)
+	Install(ctx context.Context) (string, error)
 	Setup(ctx context.Context, dir string) error
+	DownloadURL(ctx context.Context) (string, error)
 	Version() string
 }

--- a/workspace/buildpack_loader.go
+++ b/workspace/buildpack_loader.go
@@ -84,7 +84,7 @@ func LoadBuildPacks(ctx context.Context, installTarget runtime.Target, dependenc
 
 		// Install if needed
 		startTime := time.Now()
-		err, installedDir := bt.Install(ctx)
+		installedDir, err := bt.Install(ctx)
 		if err != nil {
 			return setupTimers, fmt.Errorf("Unable to install tool %s: %v", toolSpec, err)
 		}


### PR DESCRIPTION
A Go project can then add a .goreleaser.yml to setup how it would upload
assets to any SCM provider

Next step: add it to our own release build step
