### PR TITLE
Fixes to how we download OpenJDK versions

### DIFF
--- a/buildpacks/openjdk.go
+++ b/buildpacks/openjdk.go
@@ -21,30 +21,38 @@ type JavaBuildTool struct {
 
 func NewJavaBuildTool(toolSpec BuildToolSpec) JavaBuildTool {
 
-	vparts := strings.SplitN(toolSpec.Version, "+", 2)
-	subVersion := ""
 	version := toolSpec.Version
+
+	vparts := strings.SplitN(version, "+", 2)
+	subVersion := ""
 	if len(vparts) > 1 {
 		subVersion = vparts[1]
 		version = vparts[0]
 	}
 
 	parts := strings.Split(version, ".")
-	c := len(parts)
 
-	var majorVersion int64
-	var minorVersion int64
-	var patchVersion int64
-
-	if c >= 1 {
-		majorVersion, _ = strconv.ParseInt(parts[0], 0, 64)
-		if c >= 2 {
-			minorVersion, _ = strconv.ParseInt(parts[1], 0, 64)
-			if c >= 3 {
-				patchVersion, _ = strconv.ParseInt(parts[2], 0, 64)
-			}
-		}
+	majorVersion, err := convertVersionPiece(parts, 0)
+	if err != nil {
+		log.Debugf("Error when parsing majorVersion %d: %v", majorVersion, err)
 	}
+	minorVersion, err := convertVersionPiece(parts, 1)
+	if err != nil {
+		log.Debugf("Error when parsing minorVersion %d: %v", minorVersion, err)
+	}
+	patchVersion, err := convertVersionPiece(parts, 2)
+	if err != nil {
+		log.Debugf("Error when parsing patchVersion %d: %v", patchVersion, err)
+	}
+
+	// Sometimes a patchVersion can represent a subVersion
+	// e.g.: java:8.252.09 instead of java:8.252+09
+	if majorVersion != 11 && majorVersion != 14 && subVersion == "" && patchVersion > 0 && patchVersion < 100 {
+		subVersion = fmt.Sprintf("%02d", patchVersion)
+	}
+
+	log.Debugf("majorVersion: %d, minorVersion: %d, patchVersion: %d, subVersion: %s",
+		majorVersion, minorVersion, patchVersion, subVersion)
 
 	// Maybe we just require people format it with the build number?
 	// Alternatively we can have a table of defaults somewhere
@@ -61,7 +69,7 @@ func NewJavaBuildTool(toolSpec BuildToolSpec) JavaBuildTool {
 		case 12:
 			subVersion = "10"
 		case 13:
-			subVersion = "8"
+			subVersion = "9"
 		case 14:
 			subVersion = "36"
 		default:
@@ -81,35 +89,26 @@ func NewJavaBuildTool(toolSpec BuildToolSpec) JavaBuildTool {
 	return tool
 }
 
+func convertVersionPiece(parts []string, index int) (piece int64, err error) {
+	if len(parts) >= index+1 {
+		trimmed := strings.TrimLeft(parts[index], "0")
+		piece, err = strconv.ParseInt(trimmed, 0, 64)
+		if err != nil {
+			err = fmt.Errorf("failed to parse %s: %v", parts[index], err)
+		}
+	}
+	return
+}
+
 func (bt JavaBuildTool) Version() string {
 	return bt.version
 }
 
-func (bt JavaBuildTool) JavaDir(installDir string) string {
-	opsys := OS()
-	// Versions..
-	archiveDir := ""
-	if bt.majorVersion == 8 {
-		archiveDir = fmt.Sprintf("jdk%du%d-b%s", bt.majorVersion, bt.minorVersion, bt.subVersion)
-	} else {
-		archiveDir = fmt.Sprintf("jdk-%d.%d.%d+%s", bt.majorVersion, bt.minorVersion, bt.patchVersion, bt.subVersion)
-	}
-
-	basePath := filepath.Join(installDir, archiveDir)
-
-	if opsys == "darwin" {
-		basePath = filepath.Join(basePath, "Contents", "Home")
-	}
-
-	return basePath
-}
-
 func (bt JavaBuildTool) Setup(ctx context.Context, installDir string) error {
-	javaDir := bt.JavaDir(installDir)
 	t := bt.spec.InstallTarget
-	t.SetEnv("JAVA_HOME", javaDir)
+	t.SetEnv("JAVA_HOME", installDir)
 
-	cmdPath := filepath.Join(javaDir, "bin")
+	cmdPath := filepath.Join(installDir, "bin")
 	t.PrependToPath(ctx, cmdPath)
 
 	return nil
@@ -121,13 +120,19 @@ func (bt JavaBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	// Using HotSpot version, we should consider an OpenJ9 option
 	urlPattern := ""
 	if bt.majorVersion < 9 {
+		// TODO add openjdk8 OpenJ9 support
 		urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{.MajorVersion}}-binaries/releases/download/jdk{{.MajorVersion}}u{{.MinorVersion}}-b{{.SubVersion}}/OpenJDK{{.MajorVersion}}U-jdk_{{.Arch}}_{{.OS}}_hotspot_{{.MajorVersion}}u{{.MinorVersion}}b{{.SubVersion}}.{{.Extension}}"
 	} else {
 		if bt.majorVersion < 14 {
-			urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}.{{ .MinorVersion }}.{{ .PatchVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_x64_linux_hotspot_{{ .MajorVersion }}.{{ .MinorVersion }}.{{ .PatchVersion }}_{{ .SubVersion }}.{{ .Extension }}"
+			// OpenJDK 9 has a whole other scheme
+			if bt.majorVersion == 9 && bt.subVersion == "181" {
+				urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_{{.Arch}}_{{.OS}}_hotspot_{{ .MajorVersion }}_{{ .SubVersion }}.{{ .Extension }}"
+			} else {
+				urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}.{{ .MinorVersion }}.{{ .PatchVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_{{.Arch}}_{{.OS}}_hotspot_{{ .MajorVersion }}.{{ .MinorVersion }}.{{ .PatchVersion }}_{{ .SubVersion }}.{{ .Extension }}"
+			}
 		} else {
 			// 14: https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_aarch64_linux_hotspot_14_36.tar.gz
-			urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_x64_linux_hotspot_{{ .MajorVersion }}_{{ .SubVersion }}.{{ .Extension }}"
+			urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_{{.Arch}}_{{.OS}}_hotspot_{{ .MajorVersion }}_{{ .SubVersion }}.{{ .Extension }}"
 		}
 	}
 
@@ -167,6 +172,25 @@ func (bt JavaBuildTool) DownloadURL(ctx context.Context) (string, error) {
 	return url, err
 }
 
+func (bt JavaBuildTool) JavaDir(installDir string) string {
+	opsys := OS()
+	// Versions..
+	archiveDir := ""
+	if bt.majorVersion == 8 {
+		archiveDir = fmt.Sprintf("jdk%du%d-b%s", bt.majorVersion, bt.minorVersion, bt.subVersion)
+	} else {
+		archiveDir = fmt.Sprintf("jdk-%d.%d.%d+%s", bt.majorVersion, bt.minorVersion, bt.patchVersion, bt.subVersion)
+	}
+
+	basePath := filepath.Join(installDir, archiveDir)
+
+	if opsys == "darwin" {
+		basePath = filepath.Join(basePath, "Contents", "Home")
+	}
+
+	return basePath
+}
+
 func (bt JavaBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
@@ -198,6 +222,6 @@ func (bt JavaBuildTool) Install(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return javaInstallDir, nil
+	return javaPath, nil
 
 }

--- a/buildpacks/openjdk_test.go
+++ b/buildpacks/openjdk_test.go
@@ -6,13 +6,50 @@ import (
 )
 
 func TestOpenJDKUrlGeneration(t *testing.T) {
+	// NOTE This can go on forever, so we better come up with a generic and reliable way of keep tools versions up to date
 	for _, data := range []struct {
 		version string
 		url     string
 	}{
 		{
+			version: "9+181",
+			url:     "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk-9%2B181/OpenJDK9U-jdk_x64_linux_hotspot_9_181.tar.gz",
+		},
+		{
+			version: "8.252+09",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u252b09.tar.gz",
+		},
+		{
+			version: "8.252.9",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u252b09.tar.gz",
+		},
+		{
+			version: "8.252.09",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u252b09.tar.gz",
+		},
+		{
+			version: "8.242+08",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
+		},
+		{
+			version: "8.242.8",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
+		},
+		{
 			version: "8.242.08",
 			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
+		},
+		{
+			version: "8.232+09",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz",
+		},
+		{
+			version: "8.232.09",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz",
+		},
+		{
+			version: "8.232.9",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz",
 		},
 		{
 			version: "11.0.6",
@@ -21,6 +58,18 @@ func TestOpenJDKUrlGeneration(t *testing.T) {
 		{
 			version: "11.0.6+10",
 			url:     "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz",
+		},
+		{
+			version: "12.0.2+10",
+			url:     "https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jdk_x64_linux_hotspot_12.0.2_10.tar.gz",
+		},
+		{
+			version: "13.0.2+8",
+			url:     "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_x64_linux_hotspot_13.0.2_8.tar.gz",
+		},
+		{
+			version: "13.0.1+9",
+			url:     "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9/OpenJDK13U-jdk_x64_linux_hotspot_13.0.1_9.tar.gz",
 		},
 		{
 			version: "14",
@@ -35,12 +84,12 @@ func TestOpenJDKUrlGeneration(t *testing.T) {
 
 		url, err := bt.DownloadURL(context.Background())
 		if err != nil {
-			t.Fatalf("Template wasn't applied correctly: %v", err)
+			t.Fatalf("Unable to generate download URL: %v", err)
 		}
 		wanted := data.url
 
 		if url != wanted {
-			t.Errorf("Wanted: '%s'; got '%s'", wanted, url)
+			t.Errorf("Wanted:\n'%s'; got:\n'%s'", wanted, url)
 		}
 	}
 }

--- a/runtime/metal.go
+++ b/runtime/metal.go
@@ -205,6 +205,8 @@ func (t *MetalTarget) ExecToStdoutWithEnv(ctx context.Context, cmdString string,
 	cmd.Stderr = os.Stdout
 	cmd.Env = env
 
+	log.Debugf("Process env: %v", env)
+
 	err = cmd.Run()
 
 	if err != nil {


### PR DESCRIPTION
Download URL for AdoptJDK is kind of a chalenge, we'll need to think
this through.
This fixes:
1. JAVA_HOME setting is now correctly done
2. PATH for $JAVA_HOME/bin is correct too

This adds more test data, with versioning being done for either by
giving 8.252.09 or 8.252+09 (e.g.).
