### PR TITLE
beholders eye/bug/ch1592/android buildpacks

### DIFF
--- a/workspace/buildpack_loader.go
+++ b/workspace/buildpack_loader.go
@@ -56,6 +56,8 @@ func LoadBuildPacks(ctx context.Context, installTarget runtime.Target, dependenc
 			bt = buildpacks.NewAndroidNdkBuildTool(spec)
 		case "android":
 			bt = buildpacks.NewAndroidBuildTool(spec)
+		case "androidsdk":
+			bt = buildpacks.NewAndroidBuildTool(spec)
 		case "gradle":
 			bt = buildpacks.NewGradleBuildTool(spec)
 		case "flutter":


### PR DESCRIPTION
- Android: supports "android" and "androidsdk" build pack names
- Use WriteFileContents to write license agreements
