### PR TITLE
buildpacks: fix and log dropped error

### DIFF
--- a/buildpacks/golang.go
+++ b/buildpacks/golang.go
@@ -110,6 +110,10 @@ func (bt GolangBuildTool) Install(ctx context.Context) (string, error) {
 
 	log.Infof("Downloading from URL %s ...", downloadURL)
 	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Error downloading file: %v", err)
+		return "", err
+	}
 
 	err = t.Unarchive(ctx, localFile, installDir)
 	if err != nil {


### PR DESCRIPTION
This logs and handles a dropped `err` variable in the `buildpacks` package.