### PR TITLE
Version string now shows the build datetime

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -7,7 +7,7 @@ build_targets:
   - name: default
     commands:
       - go test ./...
-      - go build
+      - bash -c "go build -ldflags \"-X 'main.date=$(date)'\""
 
   - name: release
     build_after:

--- a/cli/build.go
+++ b/cli/build.go
@@ -23,6 +23,7 @@ const TIME_FORMAT = "15:04:05 MST"
 type BuildCmd struct {
 	Channel          string
 	Version          string
+	Date             string
 	ExecPrefix       string
 	NoContainer      bool
 	DependenciesOnly bool

--- a/cli/version.go
+++ b/cli/version.go
@@ -11,6 +11,7 @@ import (
 type VersionCmd struct {
 	Version string
 	Channel string
+	Date    string
 }
 
 func (*VersionCmd) Name() string     { return "version" }
@@ -23,7 +24,10 @@ func (p *VersionCmd) SetFlags(f *flag.FlagSet) {
 }
 
 func (p *VersionCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	versionString := fmt.Sprintf("Version: %s Channel: %s", p.Version, p.Channel)
+	versionString := "Version: " + p.Version + " Channel: " + p.Channel
+	if p.Date != "" {
+		versionString = versionString + " Date: " + p.Date
+	}
 	fmt.Println(versionString)
 	return subcommands.ExitSuccess
 }

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 	cmdr.Register(cmdr.HelpCommand(), "")
 	cmdr.Register(cmdr.FlagsCommand(), "")
 	cmdr.Register(cmdr.CommandsCommand(), "")
-	cmdr.Register(&BuildCmd{Version: version, Channel: channel}, "")
+	cmdr.Register(&BuildCmd{Version: version, Channel: channel, Date: date}, "")
 	cmdr.Register(&CheckConfigCmd{}, "")
 	cmdr.Register(&ConfigCmd{}, "")
 	cmdr.Register(&ExecCmd{}, "")
@@ -32,7 +32,7 @@ func main() {
 	cmdr.Register(&RunCmd{}, "")
 	cmdr.Register(&UpdateCmd{}, "")
 	cmdr.Register(&WorkspaceCmd{}, "")
-	cmdr.Register(&VersionCmd{Version: version, Channel: channel}, "")
+	cmdr.Register(&VersionCmd{Version: version, Channel: channel, Date: date}, "")
 
 	flag.Parse()
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Helps a lot when building locally, and could help us understand how
users installs newer versions
