### PR TITLE
Some tools need an output/home dir for artifacts

### DIFF
--- a/buildpacks/android_sdk.go
+++ b/buildpacks/android_sdk.go
@@ -103,7 +103,7 @@ func (bt AndroidBuildTool) Setup(ctx context.Context, androidDir string) error {
 
 	log.Infof("Setting ANDROID_SDK_ROOT to %s", androidDir)
 	t.SetEnv("ANDROID_SDK_ROOT", androidDir)
-	t.SetEnv("ANDROID_HOME", androidDir)
+	t.SetEnv("ANDROID_HOME", filepath.Join(t.ToolOutputSharedDir(ctx), "android", bt.Version()))
 
 	log.Infof("Writing agreement hashes...")
 	if !bt.writeAgreements(ctx, androidDir) {

--- a/buildpacks/golang.go
+++ b/buildpacks/golang.go
@@ -67,7 +67,7 @@ func (bt GolangBuildTool) Version() string {
 func (bt GolangBuildTool) Setup(ctx context.Context, golangDir string) error {
 	t := bt.spec.InstallTarget
 
-	goPath := t.ToolsDir(ctx)
+	goPath := filepath.Join(t.ToolOutputSharedDir(ctx), "go", bt.Version())
 	pkgPath := bt.spec.PackageDir
 
 	var goPathElements = []string{goPath, pkgPath}
@@ -84,7 +84,7 @@ func (bt GolangBuildTool) Setup(ctx context.Context, golangDir string) error {
 
 	log.Infof("Setting GOROOT to %s", golangDir)
 	t.SetEnv("GOROOT", golangDir)
-	log.Infof("Setting GOPATH to %s", goPath)
+	log.Infof("Setting GOPATH to %s", goPathVar)
 	t.SetEnv("GOPATH", goPathVar)
 
 	return nil

--- a/buildpacks/gradle.go
+++ b/buildpacks/gradle.go
@@ -60,7 +60,7 @@ func (bt GradleBuildTool) Version() string {
 func (bt GradleBuildTool) Setup(ctx context.Context, gradleDir string) error {
 	t := bt.spec.InstallTarget
 
-	gradleHome := filepath.Join(t.ToolsDir(ctx), "gradle-home", bt.Version())
+	gradleHome := filepath.Join(t.ToolOutputSharedDir(ctx), "gradle-home", bt.Version())
 
 	log.Infof("Setting GRADLE_USER_HOME to %s", gradleHome)
 	t.SetEnv("GRADLE_USER_HOME", gradleHome)

--- a/buildpacks/python.go
+++ b/buildpacks/python.go
@@ -127,26 +127,26 @@ func (bt PythonBuildTool) Setup(ctx context.Context, condaDir string) error {
 
 	if t.PathExists(ctx, envDir) {
 		log.Infof("environment installed in %s", envDir)
-	} else {
-		setupDir := bt.spec.PackageDir
-		condaBin := filepath.Join(condaDir, "bin", "conda")
+		return nil
+	}
+	setupDir := bt.spec.PackageDir
+	condaBin := filepath.Join(condaDir, "bin", "conda")
 
-		for _, cmd := range []string{
-			fmt.Sprintf("%s install -c anaconda setuptools", condaBin),
-			fmt.Sprintf("%s config --set always_yes yes --set changeps1 no", condaBin),
-			fmt.Sprintf("%s update -q conda", condaBin),
-			fmt.Sprintf("%s create --prefix %s python=%s", condaBin, envDir, bt.Version()),
-		} {
-			log.Infof("Running: '%v' ", cmd)
-			p := runtime.Process{
-				Command:   cmd,
-				Directory: setupDir,
-			}
+	for _, cmd := range []string{
+		fmt.Sprintf("%s install -c anaconda setuptools", condaBin),
+		fmt.Sprintf("%s config --set always_yes yes --set changeps1 no", condaBin),
+		fmt.Sprintf("%s update -q conda", condaBin),
+		fmt.Sprintf("%s create --prefix %s python=%s", condaBin, envDir, bt.Version()),
+	} {
+		log.Infof("Running: '%v' ", cmd)
+		p := runtime.Process{
+			Command:   cmd,
+			Directory: setupDir,
+		}
 
-			if err := t.Run(ctx, p); err != nil {
-				log.Errorf("Unable to run setup command: %s", cmd)
-				return fmt.Errorf("running '%s': %v", cmd, err)
-			}
+		if err := t.Run(ctx, p); err != nil {
+			log.Errorf("Unable to run setup command: %s", cmd)
+			return fmt.Errorf("running '%s': %v", cmd, err)
 		}
 	}
 

--- a/buildpacks/ruby.go
+++ b/buildpacks/ruby.go
@@ -182,7 +182,7 @@ func (bt RubyBuildTool) Install(ctx context.Context) (string, error) {
 func (bt RubyBuildTool) Setup(ctx context.Context, rubyDir string) error {
 	t := bt.spec.InstallTarget
 
-	gemsDir := filepath.Join(t.ToolsDir(ctx), "rubygems")
+	gemsDir := filepath.Join(t.ToolOutputSharedDir(ctx), "rubygems")
 
 	log.Infof("Setting GEM_HOME to %s", gemsDir)
 	t.SetEnv("GEM_HOME", gemsDir)

--- a/buildpacks/rust.go
+++ b/buildpacks/rust.go
@@ -34,7 +34,7 @@ func (bt RustBuildTool) Setup(ctx context.Context, rustDir string) error {
 
 	t.PrependToPath(ctx, filepath.Join(rustDir, "bin"))
 
-	t.SetEnv("CARGO_HOME", rustDir)
+	t.SetEnv("CARGO_HOME", filepath.Join(t.ToolOutputSharedDir(ctx), "rust", bt.Version()))
 	t.SetEnv("RUSTUP_HOME", rustDir)
 
 	return nil

--- a/runtime/containers.go
+++ b/runtime/containers.go
@@ -18,9 +18,10 @@ import (
 
 const (
 	// Linux container defaults
-	containerDefaultToolsDir = "/opt/yb/tools"
-	containerDefaultCacheDir = "/opt/yb/cache"
-	containerDefaultWorkDir  = "/workspace"
+	containerDefaultToolsDir            = "/opt/yb/tools"
+	containerDefaultCacheDir            = "/opt/yb/cache"
+	containerDefaultToolOutputSharedDir = "/opt/yb/output"
+	containerDefaultWorkDir             = "/workspace"
 )
 
 type ContainerTarget struct {
@@ -80,6 +81,13 @@ func (t *ContainerTarget) ToolsDir(ctx context.Context) string {
 	return containerDefaultToolsDir
 }
 
+func (t *ContainerTarget) ToolOutputSharedDir(ctx context.Context) string {
+	err := narwhal.MkdirAll(ctx, narwhal.DockerClient(), t.Container.Id, containerDefaultToolOutputSharedDir)
+	if err != nil {
+		return ""
+	}
+	return defaultOutputSharedDir
+}
 func (t *ContainerTarget) PathExists(ctx context.Context, path string) bool {
 	// Assume we can use stat for now
 	statCmd := fmt.Sprintf("stat %s", path)

--- a/runtime/containers.go
+++ b/runtime/containers.go
@@ -76,6 +76,7 @@ func (t *ContainerTarget) Architecture() Architecture {
 func (t *ContainerTarget) ToolsDir(ctx context.Context) string {
 	err := narwhal.MkdirAll(ctx, narwhal.DockerClient(), t.Container.Id, containerDefaultToolsDir)
 	if err != nil {
+		log.Errorf("Unable to create %s inside the container: %v", containerDefaultToolsDir, err)
 		return ""
 	}
 	return containerDefaultToolsDir
@@ -84,9 +85,10 @@ func (t *ContainerTarget) ToolsDir(ctx context.Context) string {
 func (t *ContainerTarget) ToolOutputSharedDir(ctx context.Context) string {
 	err := narwhal.MkdirAll(ctx, narwhal.DockerClient(), t.Container.Id, containerDefaultToolOutputSharedDir)
 	if err != nil {
+		log.Errorf("Unable to create %s inside the container: %v", containerDefaultToolOutputSharedDir, err)
 		return ""
 	}
-	return defaultOutputSharedDir
+	return containerDefaultToolOutputSharedDir
 }
 func (t *ContainerTarget) PathExists(ctx context.Context, path string) bool {
 	// Assume we can use stat for now

--- a/runtime/metal.go
+++ b/runtime/metal.go
@@ -83,8 +83,8 @@ func toolsDir() string {
 		return toolsDir
 	}
 	// Tries to find a XDG Shared dir
-	if toolsDir := xdgdir.Runtime.Path(); toolsDir != "" {
-		return filepath.Join(toolsDir, "yourbase")
+	if toolsDir := xdgdir.Data.Path(); toolsDir != "" {
+		return filepath.Join(toolsDir, "yourbase", "tools")
 	}
 	return defaultToolsDir
 }

--- a/runtime/metal.go
+++ b/runtime/metal.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
+	"path/filepath"
 	goruntime "runtime"
 	"strings"
 	"time"
@@ -17,6 +17,12 @@ import (
 	"github.com/matishsiao/goInfo"
 	"github.com/yourbase/yb/plumbing"
 	"github.com/yourbase/yb/plumbing/log"
+	"go4.org/xdgdir"
+)
+
+const (
+	defaultOutputSharedDir = "/tmp/yourbase/shared"
+	defaultToolsDir        = "/tmp/yourbase/tools"
 )
 
 type MetalTarget struct {
@@ -65,19 +71,41 @@ func (t *MetalTarget) WriteContentsToFile(contents string, filename string) erro
 }
 
 func (t *MetalTarget) ToolsDir(ctx context.Context) string {
-	toolsDir, exists := os.LookupEnv("YB_TOOLS_DIR")
-	if !exists {
-		u, err := user.Current()
-		if err != nil {
-			toolsDir = "/tmp/yourbase/tools"
-		} else {
-			toolsDir = fmt.Sprintf("%s/.yourbase/tools", u.HomeDir)
-		}
-	}
+	toolsDir := toolsDir()
 
 	plumbing.MkdirAsNeeded(toolsDir)
 
 	return toolsDir
+}
+
+func toolsDir() string {
+	if toolsDir, exists := os.LookupEnv("YB_TOOLS_DIR"); exists {
+		return toolsDir
+	}
+	// Tries to find a XDG Shared dir
+	if toolsDir := xdgdir.Runtime.Path(); toolsDir != "" {
+		return filepath.Join(toolsDir, "yourbase")
+	}
+	return defaultToolsDir
+}
+
+func (t *MetalTarget) ToolOutputSharedDir(ctx context.Context) string {
+	dir := outputSharedDir()
+
+	plumbing.MkdirAsNeeded(dir)
+
+	return dir
+}
+
+func outputSharedDir() string {
+	if sharedDir, exists := os.LookupEnv("YB_TOOLS_OUTPUT_SHARED_DIR"); exists {
+		return sharedDir
+	}
+	// Tries to find a XDG Shared dir
+	if sharedDir := xdgdir.Data.Path(); sharedDir != "" {
+		return filepath.Join(sharedDir, "yourbase", "output")
+	}
+	return defaultOutputSharedDir
 }
 
 func (t *MetalTarget) PathExists(ctx context.Context, path string) bool {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -51,6 +51,7 @@ type Target interface {
 	PathExists(ctx context.Context, path string) bool
 	GetDefaultPath() string
 	ToolsDir(ctx context.Context) string
+	ToolOutputSharedDir(ctx context.Context) string
 	OS() Os
 	OSVersion(ctx context.Context) string
 	Architecture() Architecture


### PR DESCRIPTION
Some languages/tools/platforms uses a specific directory to store build
artifacts from deps or other resources. Go (before 1.13.x) uses GOPATH,
Ruby has GEM_HOME, Rust has CARGO_HOME, and so forth.

Uses XDG by default instead of manually setting `.yourbase` dirs

Python early return in Setup()
