### PR TITLE
Supports ssh://domain/org/project

### DIFF
--- a/types/gitremote.go
+++ b/types/gitremote.go
@@ -185,10 +185,18 @@ func parseRemote(s string) (token, user, password, domain, path, protocol string
 			path = strings.Join(remainder[1:], "/")
 		}
 	} else {
-		sides := strings.Split(afterAuth, ":")
-		if len(sides) > 1 {
-			domain = sides[0]
-			path = sides[1]
+		if t == SshRemote && !strings.Contains(afterAuth, ":") {
+			remainder := strings.Split(afterAuth, "/")
+			if len(remainder) > 1 {
+				domain = remainder[0]
+				path = strings.Join(remainder[1:], "/")
+			}
+		} else {
+			sides := strings.Split(afterAuth, ":")
+			if len(sides) > 1 {
+				domain = sides[0]
+				path = sides[1]
+			}
 		}
 	}
 

--- a/types/gitremote_test.go
+++ b/types/gitremote_test.go
@@ -108,6 +108,16 @@ func TestGitRemoteParse(t *testing.T) {
 			org:      "something",
 			rType:    SshRemote,
 		},
+		{
+			in:       "ssh://git@gitlab.xu/something/where",
+			token:    "",
+			user:     "git",
+			password: "",
+			valid:    true,
+			project:  "where",
+			org:      "something",
+			rType:    SshRemote,
+		},
 	} {
 		got := NewGitRemote(l.in)
 		t.Logf("Remote '%s'...", l.in)


### PR DESCRIPTION
This fix isn't the best one, but we'll manage to add an idiomatic one
later. I'm use to using git@domaing:org/project.git as a SSH git remote,
that made me think that this notation wasn't possible

Fixes [ch1357]
