### PR TITLE
LoadWorkspace should stay in workspace

### DIFF
--- a/cli/helpers.go
+++ b/cli/helpers.go
@@ -13,7 +13,7 @@ func GetTargetPackageNamed(file string) (Package, error) {
 	var targetPackage Package
 
 	if file == "" {
-		file = MANIFEST_FILE
+		file = ManifestFile
 	}
 
 	// check if we're just a package
@@ -47,5 +47,5 @@ func GetTargetPackageNamed(file string) (Package, error) {
 }
 
 func GetTargetPackage() (Package, error) {
-	return GetTargetPackageNamed(MANIFEST_FILE)
+	return GetTargetPackageNamed(ManifestFile)
 }

--- a/plumbing/util.go
+++ b/plumbing/util.go
@@ -76,65 +76,6 @@ func RemoveWritePermission(path string) bool {
 	return true
 }
 
-/*
- * Look in the directory above the manifest file, if there's a config.yml, use that
- * otherwise we use the directory of the manifest file as the workspace root
- */
-func FindWorkspaceRoot() (string, error) {
-	wd, err := os.Getwd()
-
-	if err != nil {
-		panic(err)
-	}
-
-	if _, err := os.Stat(filepath.Join(wd, "config.yml")); err == nil {
-		// If we're currently in the directory with the config.yml
-		return wd, nil
-	}
-
-	// Look upwards to find a manifest file
-	packageDir, err := FindNearestManifestFile()
-
-	// If we find a manifest file, check the parent directory for a config.yml
-	if err == nil {
-		parent := filepath.Dir(packageDir)
-		if _, err := os.Stat(filepath.Join(parent, "config.yml")); err == nil {
-			return parent, nil
-		} else {
-			return packageDir, nil
-		}
-	} else {
-		return "", err
-	}
-
-	// No config in the parent of the package? No workspace!
-	return "", fmt.Errorf("searching for a workspace root")
-}
-
-func FindFileUpTree(filename string) (string, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-
-	for {
-		file_path := filepath.Join(wd, filename)
-		if _, err := os.Stat(file_path); err == nil {
-			return wd, nil
-		}
-
-		wd = filepath.Dir(wd)
-
-		if strings.HasSuffix(wd, "/") {
-			return "", fmt.Errorf("searching %s, ended up at the root", filename)
-		}
-	}
-}
-
-func FindNearestManifestFile() (string, error) {
-	return FindFileUpTree(MANIFEST_FILE)
-}
-
 // Because, why not?
 // Based on https://github.com/sindresorhus/is-docker/blob/master/index.js and https://github.com/moby/moby/issues/18355
 // Discussion is not settled yet: https://stackoverflow.com/questions/23513045/how-to-check-if-a-process-is-running-inside-docker-container#25518538

--- a/types/types.go
+++ b/types/types.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	MANIFEST_FILE        = ".yourbase.yml"
+	ManifestFile        = ".yourbase.yml"
 	DOCS_URL             = "https://docs.yourbase.io"
 	DEFAULT_YB_CONTAINER = "yourbase/yb_ubuntu:18.04"
 )

--- a/workspace/package.go
+++ b/workspace/package.go
@@ -81,7 +81,7 @@ func (p Package) BuildRoot() string {
 
 func LoadPackage(name string, path string) (Package, error) {
 	manifest := BuildManifest{}
-	buildYaml := filepath.Join(path, MANIFEST_FILE)
+	buildYaml := filepath.Join(path, ManifestFile)
 	if _, err := os.Stat(buildYaml); os.IsNotExist(err) {
 		return Package{}, ErrNoManifestFile
 	}
@@ -89,7 +89,7 @@ func LoadPackage(name string, path string) (Package, error) {
 	buildyaml, _ := ioutil.ReadFile(buildYaml)
 	err := yaml.Unmarshal([]byte(buildyaml), &manifest)
 	if err != nil {
-		return Package{}, fmt.Errorf("loading %s for %s: %v", MANIFEST_FILE, name, err)
+		return Package{}, fmt.Errorf("loading %s for %s: %v", ManifestFile, name, err)
 	}
 
 	p := Package{


### PR DESCRIPTION
Code move, some more `fmt.Errorf` fixes. The idea is to debug and fix a
project that would have nested `.yourbase.yml` files

Also unexports workspace loading symbols
