### PR TITLE
Fix for /tmp permissions issue

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -10,6 +10,7 @@ build_targets:
       - bash -c "go build -ldflags \"-X 'main.date=$(date)'\""
 
   - name: integration
+    host_only: true
     commands:
       - bash -c "cd integration-tests; yb build -no-container"
       - bash -c "cd integration-tests; yb build -no-container python"

--- a/buildpacks/android_sdk.go
+++ b/buildpacks/android_sdk.go
@@ -82,7 +82,7 @@ func (bt AndroidBuildTool) writeAgreements(ctx context.Context, androidDir strin
 
 	licensesDir := filepath.Join(androidDir, "licenses")
 	t := bt.spec.InstallTarget
-	t.MkdirAsNeeded(ctx, licensesDir)
+	t.MkdirAll(ctx, licensesDir)
 
 	for filename, hash := range agreements {
 		agreementFile := filepath.Join(licensesDir, filename)

--- a/buildpacks/glide.go
+++ b/buildpacks/glide.go
@@ -82,7 +82,7 @@ func (bt GlideBuildTool) Install(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	t.MkdirAsNeeded(ctx, glideDir)
+	t.MkdirAll(ctx, glideDir)
 	log.Infof("Extracting glide %s to %s...", bt.Version(), glideDir)
 	err = t.Unarchive(ctx, localFile, glideDir)
 	if err != nil {

--- a/buildpacks/homebrew.go
+++ b/buildpacks/homebrew.go
@@ -118,7 +118,7 @@ func (bt HomebrewBuildTool) Install(ctx context.Context) (string, error) {
 	t := bt.spec.InstallTarget
 
 	installDir := filepath.Join(t.ToolsDir(ctx), "homebrew")
-	t.MkdirAsNeeded(ctx, installDir)
+	t.MkdirAll(ctx, installDir)
 
 	// Normally we want to put this in the tools dir; for now we put it in the build dir because I'm not
 	// sure how to handle installation of multiple versions of things via Brew so this will allow project-specific

--- a/buildpacks/openjdk.go
+++ b/buildpacks/openjdk.go
@@ -197,7 +197,7 @@ func (bt JavaBuildTool) Install(ctx context.Context) (string, error) {
 	javaInstallDir := filepath.Join(t.ToolsDir(ctx), "java")
 	javaPath := bt.JavaDir(javaInstallDir)
 
-	t.MkdirAsNeeded(ctx, javaInstallDir)
+	t.MkdirAll(ctx, javaInstallDir)
 
 	if t.PathExists(ctx, javaPath) {
 		log.Infof("Java v%s located in %s!", bt.Version(), javaPath)

--- a/buildpacks/openjdk_test.go
+++ b/buildpacks/openjdk_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestOpenJDKUrlGeneration(t *testing.T) {
-	// NOTE This can go on forever, so we better come up with a generic and reliable way of keep tools versions up to date
+	// NOTE This can go on forever, so we better come up with a generic and reliable way of keeping tools versions up to date
 	for _, data := range []struct {
 		version string
 		url     string

--- a/buildpacks/rlang.go
+++ b/buildpacks/rlang.go
@@ -91,7 +91,7 @@ func (bt RLangBuildTool) Install(ctx context.Context) (string, error) {
 		}
 	}
 
-	t.MkdirAsNeeded(ctx, rlangDir)
+	t.MkdirAll(ctx, rlangDir)
 	p := runtime.Process{
 		Command:   "./configure --with-x=no --prefix=" + rlangDir,
 		Directory: srcDir,

--- a/buildpacks/ruby.go
+++ b/buildpacks/ruby.go
@@ -143,7 +143,7 @@ func (bt RubyBuildTool) Install(ctx context.Context) (string, error) {
 	}
 
 	pluginsDir := filepath.Join(rbenvDir, "plugins")
-	t.MkdirAsNeeded(ctx, pluginsDir)
+	t.MkdirAll(ctx, pluginsDir)
 
 	rubyBuildGitUrl := "https://github.com/rbenv/ruby-build.git"
 	rubyBuildDir := filepath.Join(pluginsDir, "ruby-build")

--- a/buildpacks/rust.go
+++ b/buildpacks/rust.go
@@ -33,8 +33,11 @@ func (bt RustBuildTool) Setup(ctx context.Context, rustDir string) error {
 	t := bt.spec.InstallTarget
 
 	t.PrependToPath(ctx, filepath.Join(rustDir, "bin"))
+	rustCargoHome := filepath.Join(t.ToolOutputSharedDir(ctx), "rust", bt.Version())
 
-	t.SetEnv("CARGO_HOME", filepath.Join(t.ToolOutputSharedDir(ctx), "rust", bt.Version()))
+	log.Infof("Setting CARGO_HOME to %s", rustCargoHome)
+	t.SetEnv("CARGO_HOME", rustCargoHome)
+	log.Infof("Setting RUSTUP_HOME to %s", rustDir)
 	t.SetEnv("RUSTUP_HOME", rustDir)
 
 	return nil

--- a/buildpacks/rust.go
+++ b/buildpacks/rust.go
@@ -60,7 +60,7 @@ func (bt RustBuildTool) Install(ctx context.Context) (string, error) {
 
 	installDir := filepath.Join(t.ToolsDir(ctx), "rust")
 	rustDir := filepath.Join(installDir, "rust-"+bt.Version())
-	t.MkdirAsNeeded(ctx, installDir)
+	t.MkdirAll(ctx, installDir)
 
 	if t.PathExists(ctx, rustDir) {
 		log.Infof("Rust v%s located in %s!", bt.Version(), rustDir)

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/yourbase/yb
 
 require (
 	github.com/beholders-eye/diffparser v0.0.0-20190814025112-fcedf0a097ba
-	github.com/blang/semver v3.1.0+incompatible
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/containerd v1.3.6 // indirect
-	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
+	github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/equinox-io/equinox v1.2.0
 	github.com/frankban/quicktest v1.5.0 // indirect
@@ -34,14 +34,14 @@ require (
 	github.com/ulikunitz/xz v0.5.7
 	github.com/waigani/diffparser v0.0.0-20190828052634-7391f219313d // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
-	github.com/yourbase/narwhal v0.5.2
+	github.com/yourbase/narwhal v0.5.3
 	go4.org v0.0.0-20200411211856-f5505b9728dd
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
 	golang.org/x/mod v0.3.0
-	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
-	google.golang.org/genproto v0.0.0-20200701001935-0939c5918c31 // indirect
+	golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666 // indirect
+	google.golang.org/genproto v0.0.0-20200721032028-5044d0edf986 // indirect
 	google.golang.org/grpc v1.30.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/ini.v1 v1.57.0

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/beholders-eye/diffparser v0.0.0-20190814025112-fcedf0a097ba h1:cmh1vt
 github.com/beholders-eye/diffparser v0.0.0-20190814025112-fcedf0a097ba/go.mod h1:jzq47XEg545Xz8V+iS6XMc0ajIfbrKVBqW/CdP9YEqs=
 github.com/blang/semver v3.1.0+incompatible h1:7hqmJYuaEK3qwVjWubYiht3j93YI0WQBuysxHIfUriU=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -59,8 +61,8 @@ github.com/containerd/containerd v1.3.6 h1:SMfcKoQyWhaRsYq7290ioC6XFcHDNcHvcEMjF
 github.com/containerd/containerd v1.3.6/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20200228182428-0f16d7a0959c/go.mod h1:Dq467ZllaHgAtVp4p1xUQWBrFXR9s/wyoTpG8zOJGkY=
-github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb h1:nXPkFq8X1a9ycY3GYQpFNxHh3j2JgY7zDZfq2EXMIzk=
-github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb/go.mod h1:Dq467ZllaHgAtVp4p1xUQWBrFXR9s/wyoTpG8zOJGkY=
+github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe h1:PEmIrUvwG9Yyv+0WKZqjXfSFDeZjs/q15g0m08BYS9k=
+github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe/go.mod h1:cECdGN1O8G9bgKTlLhuPJimka6Xb/Gg7vYzCTNVxhvo=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de h1:dlfGmNcE3jDAecLqwKPMNX6nk2qh1c1Vg1/YTzpOOF4=
@@ -402,8 +404,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
-github.com/yourbase/narwhal v0.5.2 h1:eyrkoDHgVSQUgfTdVRIB/WR9KKYgC+RbrscwJN8X+dc=
-github.com/yourbase/narwhal v0.5.2/go.mod h1:E3CDnwheEjNSYK+ISGCoE805lBzm+qfG2tDA5M1s+mk=
+github.com/yourbase/narwhal v0.5.3 h1:qJzTSuM/5Wf3XQFQLdEGW0af/Kjt1UIsyW6hlgzqZCU=
+github.com/yourbase/narwhal v0.5.3/go.mod h1:E3CDnwheEjNSYK+ISGCoE805lBzm+qfG2tDA5M1s+mk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -427,6 +429,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 h1:DZhuSZLsGlFL4CmhA8BcRA0mnthyA/nZ00AqCUo7vHg=
+golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -482,8 +486,8 @@ golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -525,8 +529,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20u
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200610111108-226ff32320da h1:bGb80FudwxpeucJUjPYJXuJ8Hk91vNtfvrymzwiei38=
 golang.org/x/sys v0.0.0-20200610111108-226ff32320da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666 h1:gVCS+QOncANNPlmlO1AhlU3oxs4V9z+gTtPwIk3p2N8=
+golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -607,8 +611,8 @@ google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200610104632-a5b850bcf112 h1:iwoQI4kCHAgRg0oltV6+Jnq5COzoS0NN+QLqHewrf5U=
 google.golang.org/genproto v0.0.0-20200610104632-a5b850bcf112/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
-google.golang.org/genproto v0.0.0-20200701001935-0939c5918c31 h1:Of4QP8bfRqzDROen6+s2j/p0jCPgzvQRd9nHiactfn4=
-google.golang.org/genproto v0.0.0-20200701001935-0939c5918c31/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200721032028-5044d0edf986 h1:10ohwcLf82I55O/aQxYqmWKoOdNbQTYYComeP1KDOS4=
+google.golang.org/genproto v0.0.0-20200721032028-5044d0edf986/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/runtime/commandprocessor.go
+++ b/runtime/commandprocessor.go
@@ -1,0 +1,75 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/shlex"
+)
+
+type distro int
+
+type command struct {
+	parts    []string
+	cowPower bool
+	valid    bool
+}
+
+// newCommand returns a command struct after checking each command string for package manager "names"
+// it also checks for valid style, using shlex
+func newCommand(cmd string) (command, error) {
+	// A little, at first, naive but realistic table
+	// of Linux package managers
+	privileged := []string{
+		"apt",      // Debian based
+		"dpkg",     // Debian based
+		"apk",      // Alpine
+		"yum",      // Redhat/CentOS based
+		"rpm",      // Redhat/CentOS based
+		"urpmi",    // Mageia
+		"zipper",   // openSUSE
+		"dnf",      // Fedora
+		"pacman",   // Arch
+		"xbps",     // Void
+		"brew",     // Homebrew
+		"nix-env",  // Nix from NixOS
+		"emerge",   // Gentoo
+		"ebuild",   // Gentoo
+		"cave",     // Exherbo
+		"slackpkg", // Slackware
+	}
+	words, err := shlex.Split(cmd)
+	c := command{parts: words, valid: true}
+
+	if err != nil {
+		c.valid = false
+		return c, err
+	}
+
+	for _, word := range words {
+		for _, pkg := range privileged {
+			if priv := strings.HasPrefix(word, pkg); priv {
+				c.cowPower = priv
+				return c, nil
+			}
+		}
+	}
+
+	return c, nil
+}
+
+func privilegedCommands(cmdString string) ([]string, error) {
+	cmd, err := newCommand(cmdString)
+	if err != nil {
+		return nil, fmt.Errorf("parsing shell like syntax of: %s: %w", cmdString, err)
+	}
+	var cmdArgs []string
+	if cmd.valid && cmd.cowPower {
+		// Should use sudo or su
+		if cmd.parts[0] != "sudo" {
+			cmdArgs = append(cmdArgs, "sudo")
+		}
+	}
+	cmdArgs = append(cmdArgs, cmd.parts...)
+	return cmdArgs, nil
+}

--- a/runtime/metal.go
+++ b/runtime/metal.go
@@ -137,7 +137,7 @@ func (t *MetalTarget) GetDefaultPath() string {
 // CacheDir returns a local filesystem cache path to hold tools distributed archives
 func (t *MetalTarget) CacheDir(ctx context.Context) string {
 	dir := localCacheDir()
-	t.MkdirAsNeeded(ctx, dir)
+	t.MkdirAll(ctx, dir)
 
 	return dir
 }
@@ -213,7 +213,7 @@ func (t *MetalTarget) Run(ctx context.Context, p Process) error {
 func (t *MetalTarget) SetEnv(key string, value string) error {
 	return os.Setenv(key, value)
 }
-func (t *MetalTarget) MkdirAsNeeded(ctx context.Context, path string) error {
+func (t *MetalTarget) MkdirAll(ctx context.Context, path string) error {
 	return plumbing.MkdirAsNeeded(path)
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -21,8 +21,6 @@ const (
 	Unknown
 )
 
-const ()
-
 type Architecture int
 
 const (
@@ -57,7 +55,7 @@ type Target interface {
 	OS() Os
 	OSVersion(ctx context.Context) string
 	Architecture() Architecture
-	MkdirAsNeeded(ctx context.Context, path string) error
+	MkdirAll(ctx context.Context, path string) error
 }
 
 type Process struct {

--- a/workspace/build_target.go
+++ b/workspace/build_target.go
@@ -83,9 +83,12 @@ func (bt BuildTarget) Build(ctx context.Context, runtimeCtx *runtime.Runtime, ou
 
 		buildContainer := bt.Container
 		buildContainer.Command = "/usr/bin/tail -f /dev/null"
-		buildContainer.Label = "build"
+		if buildContainer.Label == "" {
+			buildContainer.Label = "build"
+		}
 
 		// Append build environment variables
+		// TODO this actually removes anything defined in the YML!
 		buildContainer.Environment = []string{}
 
 		// Add package to mounts @ /workspace
@@ -126,10 +129,22 @@ func (bt BuildTarget) Build(ctx context.Context, runtimeCtx *runtime.Runtime, ou
 
 		// Inject a .ssh/config to skip host key checking
 		sshConfig := "Host github.com\n\tStrictHostKeyChecking no\n"
-		builder.Run(ctx, runtime.Process{Output: output, Command: "mkdir -p /root/.ssh"})
-		builder.WriteFileContents(ctx, sshConfig, "/root/.ssh/config")
-		builder.Run(ctx, runtime.Process{Output: output, Command: "chmod 0600 /root/.ssh/config"})
-		builder.Run(ctx, runtime.Process{Output: output, Command: "chown root:root /root/.ssh/config"})
+		err = builder.Run(ctx, runtime.Process{Output: output, Command: "mkdir -p /root/.ssh"})
+		if err != nil {
+			return stepTimes, err
+		}
+		err = builder.WriteFileContents(ctx, sshConfig, "/root/.ssh/config")
+		if err != nil {
+			return stepTimes, err
+		}
+		err = builder.Run(ctx, runtime.Process{Output: output, Command: "chmod 0600 /root/.ssh/config"})
+		if err != nil {
+			return stepTimes, err
+		}
+		err = builder.Run(ctx, runtime.Process{Output: output, Command: "chown root:root /root/.ssh/config"})
+		if err != nil {
+			return stepTimes, err
+		}
 
 		// Inject a useful gitconfig
 		configlines := []string{
@@ -141,7 +156,10 @@ func (bt BuildTarget) Build(ctx context.Context, runtimeCtx *runtime.Runtime, ou
 			"insteadOf = https://bitbucket.org/",
 		}
 		gitConfig := strings.Join(configlines, "\n")
-		builder.WriteFileContents(ctx, gitConfig, "/root/.gitconfig")
+		err = builder.WriteFileContents(ctx, gitConfig, "/root/.gitconfig")
+		if err != nil {
+			return stepTimes, err
+		}
 
 		// TODO: Don't run this multiple times
 		// Map SSH agent into the container
@@ -156,10 +174,18 @@ func (bt BuildTarget) Build(ctx context.Context, runtimeCtx *runtime.Runtime, ou
 
 			builder.SetEnv("SSH_AUTH_SOCK", "/ssh_agent")
 			forwardPath, err := builder.DownloadFile(ctx, "https://yourbase-artifacts.s3-us-west-2.amazonaws.com/sockforward")
-			builder.Run(ctx, runtime.Process{Output: output, Command: fmt.Sprintf("chmod a+x %s", forwardPath)})
+			if err != nil {
+				return stepTimes, err
+			}
+			err = builder.Run(ctx, runtime.Process{Output: output, Command: fmt.Sprintf("chmod a+x %s", forwardPath)})
+			if err != nil {
+				return stepTimes, err
+			}
 			forwardCmd := fmt.Sprintf("%s /ssh_agent %s", forwardPath, hostAddr)
 			go func() {
-				builder.Run(ctx, runtime.Process{Output: output, Command: forwardCmd})
+				if err := builder.Run(ctx, runtime.Process{Output: output, Command: forwardCmd}); err != nil {
+					log.Errorf("Starting ssh_agent: %v", err)
+				}
 			}()
 		}
 
@@ -175,10 +201,6 @@ func (bt BuildTarget) Build(ctx context.Context, runtimeCtx *runtime.Runtime, ou
 		}
 
 		stepTimes = append(stepTimes, tweakTimer)
-		if err != nil {
-			return stepTimes, err
-		}
-
 	}
 
 	depContainerStartTime := time.Now()

--- a/workspace/sockforward.go
+++ b/workspace/sockforward.go
@@ -1,0 +1,62 @@
+package workspace
+
+import (
+	"context"
+	"io"
+
+	"github.com/yourbase/yb/plumbing/log"
+	"github.com/yourbase/yb/runtime"
+)
+
+// injectSockForward maps a running SSH agent into the container
+func (bt *BuildTarget) injectSockForward(ctx context.Context, builder runtime.Target, output io.Writer, agentPath, baseDir string) error {
+	// Checks if sockforward is already running inside the container
+	err := builder.Run(ctx, runtime.Process{Command: "pgrep -x sockforward"})
+	if err == nil {
+		return nil
+	}
+
+	var localSockForward = builder.ToolsDir(ctx) + "/sockforward"
+
+	hostAddr, err := runtime.ForwardUnixSocketToTcp(agentPath)
+	if err != nil {
+		log.Warnf("Could not forward SSH agent: %v", err)
+	} else {
+		log.Infof("Forwarding SSH agent via %s", hostAddr)
+	}
+
+	builder.SetEnv("SSH_AUTH_SOCK", "/ssh_agent")
+
+	// start gouroutine
+	startMe := func() {
+		log.Infof("Running SSH agent socket forwarder...")
+		forwardCmd := localSockForward + " " + baseDir + "/ssh_agent " + hostAddr
+		if err := builder.Run(ctx, runtime.Process{Output: output, Command: forwardCmd}); err != nil {
+			log.Warnf("Starting ssh_agent: %v", err)
+		}
+	}
+
+	// Not running, checks if we already injected it
+	err = builder.Run(ctx, runtime.Process{Output: output, Command: "stat " + localSockForward})
+	if err == nil {
+		// No need to download it again
+		go startMe()
+		return nil
+	}
+
+	const sockForwardURL = "https://yourbase-artifacts.s3-us-west-2.amazonaws.com/sockforward"
+	forwardPath, err := builder.DownloadFile(ctx, sockForwardURL)
+	if err != nil {
+		return err
+	}
+	err = builder.Run(ctx, runtime.Process{Output: output, Command: "chmod a+x " + forwardPath})
+	if err != nil {
+		return err
+	}
+	err = builder.Run(ctx, runtime.Process{Output: output, Command: "cp " + forwardPath + " " + localSockForward})
+	if err != nil {
+		return err
+	}
+	go startMe()
+	return nil
+}


### PR DESCRIPTION
Also adds more error checks

Tries to fix other permission issues when the container run creates
artifacts, by running inside the container as the current user

Rust's CARGO_HOME/RUSTUP_HOME should be shown to the user
