### PR TITLE
cli: dropped error variables

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -71,6 +71,11 @@ func (p *LoginCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{})
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Errorf("Couldn't read response body: %s\n", err)
+		return subcommands.ExitFailure
+	}
+
 	var tokenResponse TokenResponse
 	err = json.Unmarshal(body, &tokenResponse)
 

--- a/cli/remote_build.go
+++ b/cli/remote_build.go
@@ -732,6 +732,9 @@ func (p *RemoteCmd) fetchProject(urls []string) (*Project, GitRemote, error) {
 
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, empty, err
+	}
 	var project Project
 	err = json.Unmarshal(body, &project)
 	if err != nil {

--- a/cli/remote_build.go
+++ b/cli/remote_build.go
@@ -456,6 +456,9 @@ func shouldSkip(file string, worktree *git.Worktree) bool {
 			return true
 		}
 		dir, err := f.Readdir(0)
+		if err != nil {
+			return true
+		}
 		log.Debugf("Ls dir %s", filePath)
 		for _, f := range dir {
 			child := path.Join(file, f.Name())


### PR DESCRIPTION
This fixes three dropped `err` variables in the `cli` package.