### PR TITLE
Enables per-build_target dependencies (stable)

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -104,6 +104,7 @@ func (b *BuildCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{})
 
 	// Named target, look for that and resolve it
 	buildTargets, err := manifest.ResolveBuildTargets(buildTargetName)
+	targetPackage.BuildTargets = buildTargets
 
 	if err != nil {
 		log.Errorf("Could not compute build target '%s': %v", buildTargetName, err)

--- a/integration-tests/.yourbase.yml
+++ b/integration-tests/.yourbase.yml
@@ -1,5 +1,4 @@
 # NOTE first iteration, just testing `yb build`
-# Tries building 3 known-good Python FOSS projects
 # After fixing how the CLI manages workspaces (currently done using config.yml), we could simplify this a bit
 #
 build_targets:

--- a/integration-tests/.yourbase.yml
+++ b/integration-tests/.yourbase.yml
@@ -52,5 +52,7 @@ build_targets:
       - cp flutter/.yourbase.pin_code_test_field.yml flutter/pin_code_test_field/.yourbase.yml
       - bash -c "cd flutter/flutter-examples && yb build -no-container default; git restore ."
       - bash -c "cd flutter/pin_code_test_field && yb build -no-container default; git restore ."
+      - bash -c "cd flutter/flutter-examples && yb build -no-container beta; git restore ."
+      - bash -c "cd flutter/pin_code_test_field && yb build -no-container beta; git restore ."
       - rm flutter/flutter-examples/.yourbase.yml
       - rm flutter/pin_code_test_field/.yourbase.yml

--- a/integration-tests/flutter/.yourbase.flutter-examples.yml
+++ b/integration-tests/flutter/.yourbase.flutter-examples.yml
@@ -7,3 +7,10 @@ build_targets:
   - name: default
     commands:
       - bash -x get_packages.sh
+
+  - name: beta
+    dependencies:
+      build:
+        - flutter:1.17.2
+    commands:
+      - bash -x get_packages.sh

--- a/integration-tests/flutter/.yourbase.pin_code_test_field.yml
+++ b/integration-tests/flutter/.yourbase.pin_code_test_field.yml
@@ -12,5 +12,8 @@ build_targets:
     dependencies:
       build:
         - flutter:1.17.2
+        - python:3.8
     commands:
       - flutter packages get
+      # Temporary filed that isn't cleaned up after
+      - rm example/ios/Flutter/flutter_export_environment.sh

--- a/integration-tests/flutter/.yourbase.pin_code_test_field.yml
+++ b/integration-tests/flutter/.yourbase.pin_code_test_field.yml
@@ -7,3 +7,10 @@ build_targets:
   - name: default
     commands:
       - flutter packages get
+
+  - name: beta
+    dependencies:
+      build:
+        - flutter:1.17.2
+    commands:
+      - flutter packages get

--- a/integration-tests/flutter/.yourbase.pin_code_test_field.yml
+++ b/integration-tests/flutter/.yourbase.pin_code_test_field.yml
@@ -15,5 +15,3 @@ build_targets:
         - python:3.8
     commands:
       - flutter packages get
-      # Temporary filed that isn't cleaned up after
-      - rm example/ios/Flutter/flutter_export_environment.sh

--- a/types/build_manifest.go
+++ b/types/build_manifest.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"sort"
-	"strings"
 )
 
 const DependencyChecksumLength = 12
@@ -25,7 +23,7 @@ func (b BuildManifest) IsTargetSandboxed(target BuildTarget) bool {
 }
 
 // XXX: Support more than one level? Intuitively that seems like it will breed un-needed complexity
-func (b BuildManifest) ResolveBuildTargets(targetName string) ([]BuildTarget, error) {
+func (b *BuildManifest) ResolveBuildTargets(targetName string) ([]BuildTarget, error) {
 	targetList := make([]BuildTarget, 0)
 
 	target, err := b.BuildTarget(targetName)
@@ -44,41 +42,8 @@ func (b BuildManifest) ResolveBuildTargets(targetName string) ([]BuildTarget, er
 	}
 
 	targetList = append(targetList, target)
-	err = b.mergeBuildDependencies(targetList)
-	if err != nil {
-		return targetList, err
-	}
 
 	return targetList, nil
-}
-
-// mergeBuildDependencies will override and also merge build packs defined for each BuildTarget when
-// resolving which ones should be built in ResolveBuildTargets above. It does so by checking if the
-// Manifest already defined the same `tool:version` as the one described inside the build target
-// TODO use cue instead, to replace all this error prone behavior
-func (b BuildManifest) mergeBuildDependencies(targetList []BuildTarget) error {
-	manifestSortedBuildDepList := b.Dependencies.Build
-	sort.Strings(manifestSortedBuildDepList)
-	for _, buildTarget := range targetList {
-		for _, dep := range buildTarget.Dependencies.Build {
-			for i, globalDep := range manifestSortedBuildDepList {
-				// Extract tool prefix
-				parts := strings.Split(dep, ":")
-				if len(parts) != 2 {
-					return fmt.Errorf("merging build deps: malformed build pack definition: %s", dep)
-				}
-				toolPrefix := parts[0]
-				if strings.HasPrefix(globalDep, toolPrefix) {
-					manifestSortedBuildDepList[i] = dep // override by replacing e.g. `flutter:xxx` with `flutter:yyy`
-				}
-			}
-			if i := sort.SearchStrings(manifestSortedBuildDepList, dep); i == len(manifestSortedBuildDepList) { // dep wasn't found
-				// merge
-				manifestSortedBuildDepList = append(manifestSortedBuildDepList, dep)
-			}
-		}
-	}
-	return nil
 }
 
 func (b BuildManifest) CIBuild(buildName string) (CIBuild, error) {

--- a/types/build_manifest.go
+++ b/types/build_manifest.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"sort"
+	"strings"
 )
 
 const DependencyChecksumLength = 12
@@ -42,8 +44,41 @@ func (b BuildManifest) ResolveBuildTargets(targetName string) ([]BuildTarget, er
 	}
 
 	targetList = append(targetList, target)
+	err = b.mergeBuildDependencies(targetList)
+	if err != nil {
+		return targetList, err
+	}
 
 	return targetList, nil
+}
+
+// mergeBuildDependencies will override and also merge build packs defined for each BuildTarget when
+// resolving which ones should be built in ResolveBuildTargets above. It does so by checking if the
+// Manifest already defined the same `tool:version` as the one described inside the build target
+// TODO use cue instead, to replace all this error prone behavior
+func (b BuildManifest) mergeBuildDependencies(targetList []BuildTarget) error {
+	manifestSortedBuildDepList := b.Dependencies.Build
+	sort.Strings(manifestSortedBuildDepList)
+	for _, buildTarget := range targetList {
+		for _, dep := range buildTarget.Dependencies.Build {
+			for i, globalDep := range manifestSortedBuildDepList {
+				// Extract tool prefix
+				parts := strings.Split(dep, ":")
+				if len(parts) != 2 {
+					return fmt.Errorf("merging build deps: malformed build pack definition: %s", dep)
+				}
+				toolPrefix := parts[0]
+				if strings.HasPrefix(globalDep, toolPrefix) {
+					manifestSortedBuildDepList[i] = dep // override by replacing e.g. `flutter:xxx` with `flutter:yyy`
+				}
+			}
+			if i := sort.SearchStrings(manifestSortedBuildDepList, dep); i == len(manifestSortedBuildDepList) { // dep wasn't found
+				// merge
+				manifestSortedBuildDepList = append(manifestSortedBuildDepList, dep)
+			}
+		}
+	}
+	return nil
 }
 
 func (b BuildManifest) CIBuild(buildName string) (CIBuild, error) {

--- a/types/build_manifest.go
+++ b/types/build_manifest.go
@@ -23,7 +23,7 @@ func (b BuildManifest) IsTargetSandboxed(target BuildTarget) bool {
 }
 
 // XXX: Support more than one level? Intuitively that seems like it will breed un-needed complexity
-func (b *BuildManifest) ResolveBuildTargets(targetName string) ([]BuildTarget, error) {
+func (b BuildManifest) ResolveBuildTargets(targetName string) ([]BuildTarget, error) {
 	targetList := make([]BuildTarget, 0)
 
 	target, err := b.BuildTarget(targetName)

--- a/types/dependencies.go
+++ b/types/dependencies.go
@@ -1,0 +1,58 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (b BuildManifest) FinalBuildDependencies(targetList []BuildTarget) ([]string, error) {
+	buildDeps, err := b.mergeDeps(targetList)
+	if err != nil {
+		return nil, err
+	}
+	if len(buildDeps) > 0 {
+		return buildDeps, nil
+	}
+	return b.Dependencies.Build, nil
+}
+
+// mergeDeps overrides and merge dependencies defined per build target,
+// effectively swaping BuildManifest.Dependencies.Build []string with a new list
+func (b BuildManifest) mergeDeps(targetList []BuildTarget) ([]string, error) {
+	splitToolName := func(dep string) (tool, version string, _ error) {
+		parts := strings.SplitN(dep, ":", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("merging/overriding build localDeps: malformed build pack definition: %s", dep)
+		}
+		tool = parts[0]
+		version = parts[1]
+		return
+	}
+	depMap := make(map[string]string)
+	globalDeps := b.Dependencies.Build
+
+	for _, dep := range globalDeps {
+		tool, version, err := splitToolName(dep)
+		if err != nil {
+			return nil, err
+		}
+		depMap[tool] = version
+	}
+	// Doing this before makes locally defined deps to override the global definition
+	for _, tgt := range targetList {
+		for _, dep := range tgt.Dependencies.Build {
+			tool, version, err := splitToolName(dep)
+			if err != nil {
+				return nil, err
+			}
+			depMap[tool] = version
+		}
+	}
+	depList := make([]string, 0)
+	for k, v := range depMap {
+		toolSpec := k + ":" + v
+		depList = append(depList, toolSpec)
+	}
+
+	return depList, nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -55,6 +55,7 @@ type ExecPhase struct {
 }
 
 type BuildDependencies struct {
+	Build      []string                               `yaml:"build"`
 	Containers map[string]narwhal.ContainerDefinition `yaml:"containers"`
 }
 


### PR DESCRIPTION
Add support for overriding and merging build packs defined inside a
`build_target` as in:

```
dependencies:
  build:
    - go:1.13.2

build_targets:
  - name: default
    commands:
      - go build

  - name: next
    dependencies:
      build:
        - go:1.14.6
    commands:
      - go build
```

* Integration test for flutter changed to test it
