### PR TITLE
Enables per-build_target dependencies (runtC)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.0.3
 	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/go-cmp v0.5.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gopherjs/gopherjs v0.0.0-20190915194858-d3ddacdb130f // indirect
 	github.com/johnewart/archiver v3.1.4+incompatible

--- a/integration-tests/flutter/.yourbase.flutter-examples.yml
+++ b/integration-tests/flutter/.yourbase.flutter-examples.yml
@@ -7,3 +7,10 @@ build_targets:
   - name: default
     commands:
       - bash -x get_packages.sh
+
+  - name: beta
+    dependencies:
+      build:
+        - flutter:1.17.2
+    commands:
+      - bash -x get_packages.sh

--- a/integration-tests/flutter/.yourbase.pin_code_test_field.yml
+++ b/integration-tests/flutter/.yourbase.pin_code_test_field.yml
@@ -7,3 +7,11 @@ build_targets:
   - name: default
     commands:
       - flutter packages get
+
+  - name: beta
+    dependencies:
+      build:
+        - flutter:1.17.2
+        - python:3.8
+    commands:
+      - flutter packages get

--- a/workspace/build_target.go
+++ b/workspace/build_target.go
@@ -3,14 +3,15 @@ package workspace
 import (
 	"context"
 	"fmt"
-	"github.com/yourbase/narwhal"
-	"github.com/yourbase/yb/plumbing"
-	"github.com/yourbase/yb/plumbing/log"
-	"github.com/yourbase/yb/runtime"
 	"io"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/yourbase/narwhal"
+	"github.com/yourbase/yb/plumbing"
+	"github.com/yourbase/yb/plumbing/log"
+	"github.com/yourbase/yb/runtime"
 )
 
 type CommandTimer struct {
@@ -215,10 +216,11 @@ func (bt BuildTarget) Build(ctx context.Context, runtimeCtx *runtime.Runtime, ou
 	}
 
 	// Merge global deps with build target deps
-	buildpacks, err := bt.mergeDeps(globalDeps)
+	err := (&bt).mergeDeps(globalDeps)
 	if err != nil {
 		return stepTimes, err
 	}
+	buildpacks := bt.Dependencies.Build
 
 	buildPackStartTime := time.Now()
 	buildPackTimes, err := LoadBuildPacks(ctx, builder, buildpacks)

--- a/workspace/buildpack_loader.go
+++ b/workspace/buildpack_loader.go
@@ -3,10 +3,10 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/yourbase/yb/buildpacks"
 	"github.com/yourbase/yb/runtime"
-	"strings"
-	"time"
 
 	"github.com/yourbase/yb/plumbing/log"
 	. "github.com/yourbase/yb/types"
@@ -17,12 +17,9 @@ func LoadBuildPacks(ctx context.Context, installTarget runtime.Target, dependenc
 
 	for _, toolSpec := range dependencies {
 
-		parts := strings.Split(toolSpec, ":")
-		buildpackName := parts[0]
-		versionString := ""
-
-		if len(parts) > 1 {
-			versionString = parts[1]
+		buildpackName, versionString, err := SplitToolSpec(toolSpec)
+		if err != nil {
+			return nil, fmt.Errorf("parsing a tool spec: %w", err)
 		}
 
 		spec := buildpacks.BuildToolSpec{

--- a/workspace/dependencies.go
+++ b/workspace/dependencies.go
@@ -1,0 +1,53 @@
+package workspace
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (bt BuildTarget) mergeDeps(globalDepsList []string) ([]string, error) {
+	if len(bt.Dependencies.Build) == 0 {
+		return globalDepsList, nil
+	}
+	splitToolName := func(dep string) (tool, version string, _ error) {
+		parts := strings.SplitN(dep, ":", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("merging/overriding build localDeps: malformed build pack definition: %s", dep)
+		}
+		tool = parts[0]
+		version = parts[1]
+		return
+	}
+
+	if len(globalDepsList) == 0 {
+		return bt.Dependencies.Build, nil
+	}
+
+	globalDepsMap := make(map[string]string)
+	for _, dep := range globalDepsList {
+		tool, version, err := splitToolName(dep)
+		if err != nil {
+			return nil, err
+		}
+		globalDepsMap[tool] = version
+	}
+	buildTgtDepsMap := make(map[string]string)
+	for _, dep := range bt.Dependencies.Build {
+		tool, version, err := splitToolName(dep)
+		if err != nil {
+			return nil, err
+		}
+		buildTgtDepsMap[tool] = version
+	}
+
+	finalDepsList := make([]string, 0)
+	finalDepsList = append(finalDepsList, bt.Dependencies.Build...)
+
+	for k, v := range globalDepsMap {
+		if _, exists := buildTgtDepsMap[k]; !exists {
+			finalDepsList = append(finalDepsList, k+":"+v)
+		}
+	}
+
+	return finalDepsList, nil
+}

--- a/workspace/dependencies.go
+++ b/workspace/dependencies.go
@@ -7,18 +7,16 @@ import (
 
 func (bt *BuildTarget) mergeDeps(globalDepsList []string) error {
 	globalDepsMap := make(map[string]string)
+	buildTgtDepsMap := make(map[string]string)
 	for _, dep := range globalDepsList {
 		tool, version, err := SplitToolSpec(dep)
 		if err != nil {
 			return fmt.Errorf("merging/overriding build localDeps: %w", err)
 		}
 		globalDepsMap[tool] = version
+		buildTgtDepsMap[tool] = version
 	}
-	buildTgtDepsMap := make(map[string]string)
 	for _, dep := range bt.Dependencies.Build {
-		for tool, version := range globalDepsMap {
-			buildTgtDepsMap[tool] = version
-		}
 		tool, version, err := SplitToolSpec(dep)
 		if err != nil {
 			return fmt.Errorf("merging/overriding build localDeps: %w", err)
@@ -30,6 +28,11 @@ func (bt *BuildTarget) mergeDeps(globalDepsList []string) error {
 
 	for tool, version := range buildTgtDepsMap {
 		bt.Dependencies.Build = append(bt.Dependencies.Build, tool+":"+version)
+	}
+
+	// XXX Debug
+	for _, dep := range bt.Dependencies.Build {
+		fmt.Printf("Build Target dep: %s\n", dep)
 	}
 
 	return nil

--- a/workspace/dependencies_test.go
+++ b/workspace/dependencies_test.go
@@ -102,8 +102,8 @@ func TestMergeDeps(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			bt := &test.b.BuildTargets[0]
-			err := bt.mergeDeps(test.b.Dependencies.Build)
+			tgts := test.b.BuildTargets
+			err := tgts[0].mergeDeps(test.b.Dependencies.Build)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/workspace/dependencies_test.go
+++ b/workspace/dependencies_test.go
@@ -1,0 +1,129 @@
+package workspace
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestMergeDeps(t *testing.T) {
+	const dummyGoToolSpec = "go:1.14.6"
+	tests := []struct {
+		name string
+		b    *BuildManifest
+		want *BuildManifest
+	}{
+		{
+			name: "Global",
+			b: &BuildManifest{
+				Dependencies: DependencySet{
+					Build: []string{dummyGoToolSpec},
+				},
+				BuildTargets: []BuildTarget{
+					{
+						Name: "default",
+					},
+				},
+			},
+			want: &BuildManifest{
+				Dependencies: DependencySet{
+					Build: []string{dummyGoToolSpec},
+				},
+				BuildTargets: []BuildTarget{
+					{
+						Name: "default",
+						Dependencies: BuildDependencies{
+							Build: []string{dummyGoToolSpec},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "OverrideVersionLocally",
+			b: &BuildManifest{
+				Dependencies: DependencySet{
+					Build: []string{"go:1.13"},
+				},
+				BuildTargets: []BuildTarget{
+					{
+						Name: "default",
+						Dependencies: BuildDependencies{
+							Build: []string{"go:1.14"},
+						},
+					},
+				},
+			},
+			want: &BuildManifest{
+				Dependencies: DependencySet{
+					Build: []string{"go:1.13"},
+				},
+				BuildTargets: []BuildTarget{
+					{
+						Name: "default",
+						Dependencies: BuildDependencies{
+							Build: []string{"go:1.14"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "AddNewDepInTarget",
+			b: &BuildManifest{
+				Dependencies: DependencySet{
+					Build: []string{dummyGoToolSpec},
+				},
+				BuildTargets: []BuildTarget{
+					{
+						Name: "default",
+						Dependencies: BuildDependencies{
+							Build: []string{"java:1.8"},
+						},
+					},
+				},
+			},
+			want: &BuildManifest{
+				Dependencies: DependencySet{
+					Build: []string{dummyGoToolSpec},
+				},
+				BuildTargets: []BuildTarget{
+					{
+						Name: "default",
+						Dependencies: BuildDependencies{
+							Build: []string{"java:1.8", dummyGoToolSpec},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bt := &test.b.BuildTargets[0]
+			err := bt.mergeDeps(test.b.Dependencies.Build)
+			if err != nil {
+				t.Fatal(err)
+			}
+			diff := cmp.Diff(test.want, test.b,
+				cmpopts.EquateEmpty(),
+				// Ignore order of BuildDependencies.Build field
+				cmp.FilterPath(func(path cmp.Path) bool {
+					f, ok := path.Last().(cmp.StructField)
+					if !ok {
+						return false
+					}
+					return path.Index(-2).Type() == reflect.TypeOf(BuildDependencies{}) &&
+						f.Name() == "Build"
+				}, cmpopts.SortSlices(func(s1, s2 string) bool {
+					return s1 < s2
+				})),
+			)
+			if diff != "" {
+				t.Errorf("manifest (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For the runtime-contexxt: Add support for overriding and merging build packs defined inside a
`build_target` as in:

```
dependencies:
  build:
    - go:1.13.2

build_targets:
  - name: default
    commands:
      - go build

  - name: next
    dependencies:
      build:
        - go:1.14.6
    commands:
      - go build
```

* Integration test for flutter changed to test it

Fixes [ch1868]
