### PR TITLE
plumbing: fix dropped error

### DIFF
--- a/plumbing/patch_handle.go
+++ b/plumbing/patch_handle.go
@@ -89,6 +89,10 @@ func UnifiedPatchOnGit(patch string, commit *object.Commit, w, originWorktree *g
 			}
 			newBytes := bytes.NewBuffer(nil)
 			_, err = io.Copy(newBytes, newFile)
+			if err != nil {
+				patchError = fmt.Errorf("Unable to copy %s to a buffer: %v", file.NewName, err)
+				return ""
+			}
 			contents = newBytes.String()
 			_ = newFile.Close()
 		}


### PR DESCRIPTION
This fixes a dropped error in the `plumbing` package by logging it (as in surrounding code) and returning an empty string.