### PR TITLE
Consistent to how we log things for Go

### DIFF
--- a/buildpacks/rust.go
+++ b/buildpacks/rust.go
@@ -33,8 +33,11 @@ func (bt RustBuildTool) Setup(ctx context.Context, rustDir string) error {
 	t := bt.spec.InstallTarget
 
 	t.PrependToPath(ctx, filepath.Join(rustDir, "bin"))
+	rustCargoHome := filepath.Join(t.ToolOutputSharedDir(ctx), "rust", bt.Version())
 
-	t.SetEnv("CARGO_HOME", filepath.Join(t.ToolOutputSharedDir(ctx), "rust", bt.Version()))
+	log.Infof("Setting CARGO_HOME to %s", rustCargoHome)
+	t.SetEnv("CARGO_HOME", rustCargoHome)
+	log.Infof("Setting RUSTUP_HOME to %s", rustDir)
 	t.SetEnv("RUSTUP_HOME", rustDir)
 
 	return nil


### PR DESCRIPTION
Adds log messages to show up CARGO_HOME and RUSTUP_HOME paths to the end user
