### PR TITLE
ridai/ch1160/remotebuilds

### DIFF
--- a/cli/remote_build.go
+++ b/cli/remote_build.go
@@ -819,13 +819,14 @@ func (cmd *RemoteCmd) submitBuild(project *Project, tagMap map[string]string) er
 	patchEncoded := base64.StdEncoding.EncodeToString(patchBuffer.Bytes())
 
 	formData := url.Values{
-		"project_id": {strconv.Itoa(project.Id)},
-		"repository": {project.Repository},
-		"api_key":    {userToken},
-		"target":     {cmd.target},
-		"patch_data": {patchEncoded},
-		"commit":     {cmd.baseCommit},
-		"branch":     {cmd.branch},
+		"project_id":  {strconv.Itoa(project.Id)},
+		"repository":  {project.Repository},
+		"api_key":     {userToken},
+		"target":      {cmd.target},
+		"patch_data":  {patchEncoded},
+		"commit":      {cmd.baseCommit},
+		"commit_hash": {cmd.baseCommit},
+		"branch":      {cmd.branch},
 	}
 
 	tags := make([]string, 0)


### PR DESCRIPTION
- Flutter integration tests (runtime-context) (#128)
- apt commands stopped working (#131)
- Fixes a download error from the original #121 (#130)
- Runtime context stable release fix (#135)
- YB Integration tests should work in a container (#137)
- Enables per-build_target dependencies (runtC) (#136)
- CATS Release! (RuntC) (#140)
- Picks well known remote branch names (#142)
- Reference [ch2141] (#143)
- Adds variables.sh (#146)
- Appropriate way of finding a running container IP address (#147)
- Uses `git` to fetch and compare remote branches (#145)
- Bumps conda tool version (#148)
- plumbing: dropped error (#149)
- Consistent to how we log things for Go (#150)
- for the time being, let it there
- Revert "Bumps conda tool version (#148)"
- Node build pack fixes (#151)
- Still needs to point to main (#152)
- Tweaks relase for RuntC (#153)
- Sending both commit fields
