### PR TITLE
Flutter beta/dev channel support

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -1,6 +1,6 @@
 dependencies:
   build:
-    - go:1.14.6
+    - go:1.14.7
 
 build_targets:
   - name: default

--- a/buildpacks/flutter.go
+++ b/buildpacks/flutter.go
@@ -11,7 +11,10 @@ import (
 	"github.com/yourbase/yb/plumbing/log"
 )
 
-// https://archive.apache.org/dist/flutter/flutter-3/3.3.3/binaries/apache-flutter-3.3.3-bin.tar.gz
+// Stable channel URL example:
+// https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_1.17.5-stable.tar.xz
+// Beta channel URL example:
+// https://storage.googleapis.com/flutter_infra/releases/beta/linux/flutter_linux_1.19.0-4.2.pre-beta.tar.xz
 const flutterDistMirrorTemplate = "https://storage.googleapis.com/flutter_infra/releases/{{.Channel}}/{{.OS}}/flutter_{{.OS}}_{{.Version}}-{{.Channel}}.{{.Extension}}"
 
 type FlutterBuildTool struct {
@@ -137,7 +140,7 @@ func (bt FlutterBuildTool) Install(ctx context.Context) (string, error) {
 // was a mistake
 //
 func downloadURLVersion(version string) string {
-	version_1_17_0 := "v1.17.0"
+	version1170 := "v1.17.0"
 	compVersion := version
 
 	// Semver package requires the version to start with "v"
@@ -146,9 +149,14 @@ func downloadURLVersion(version string) string {
 	}
 
 	// Below 1.17.0 need the "v", >= to 1.17.0, remove the "v"
-	if semver.Compare(compVersion, version_1_17_0) < 0 {
+	if semver.Compare(compVersion, version1170) < 0 {
 		version = compVersion // Need the "v"
 	} else {
+		version = strings.TrimLeft(compVersion, "v")
+	}
+	if strings.Count(version, "pre") > 0 || strings.Count(version, "dev") > 0 {
+		// Beta/dev versions are considered to be newer, even if semver sees it differently
+		// Those versions started to pop up after v1.17.0: https://medium.com/flutter/flutter-spring-2020-update-f723d898d7af
 		version = strings.TrimLeft(compVersion, "v")
 	}
 

--- a/buildpacks/flutter_test.go
+++ b/buildpacks/flutter_test.go
@@ -12,6 +12,22 @@ func Test_downloadURLVersion(t *testing.T) {
 		want string
 	}{
 		{
+			in:   "1.20.2",
+			want: "1.20.2",
+		},
+		{
+			in:   "1.20.0-7.4.pre",
+			want: "1.20.0-7.4.pre",
+		},
+		{
+			in:   "1.17.0-4.1.pre",
+			want: "1.17.0-4.1.pre",
+		},
+		{
+			in:   "1.17.0-dev.3.1",
+			want: "1.17.0-dev.3.1",
+		},
+		{
 			in:   "1.17.0",
 			want: "1.17.0",
 		},


### PR DESCRIPTION
One will want to point to: `flutter:1.17.0-3.4.pre` for the experimental Web App support.
