### PR TITLE
Buildpacks fixes from runtime-context

### DIFF
--- a/buildpacks/openjdk.go
+++ b/buildpacks/openjdk.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
-        "strconv"
 
 	"github.com/johnewart/archiver"
 
@@ -14,45 +14,52 @@ import (
 	. "github.com/yourbase/yb/types"
 )
 
-
 type JavaBuildTool struct {
 	BuildTool
-	version string
-	spec    BuildToolSpec
+	version      string
+	spec         BuildToolSpec
 	majorVersion int64
 	minorVersion int64
 	patchVersion int64
-	subVersion string
+	subVersion   string
 }
 
 func NewJavaBuildTool(toolSpec BuildToolSpec) JavaBuildTool {
 
-	vparts := strings.SplitN(toolSpec.Version, "+", 2)
-	subVersion := ""
 	version := toolSpec.Version
-	if len(vparts) > 1 { 
+
+	vparts := strings.SplitN(version, "+", 2)
+	subVersion := ""
+	if len(vparts) > 1 {
 		subVersion = vparts[1]
 		version = vparts[0]
 	}
 
 	parts := strings.Split(version, ".")
-  c := len(parts)
 
-	var majorVersion int64
-	var minorVersion int64
-	var patchVersion int64
-
-	if c >= 1 {
-		majorVersion, _ = strconv.ParseInt(parts[0], 0, 64)
-		if c >= 2 {
-			minorVersion, _ = strconv.ParseInt(parts[1], 0, 64)
-			if c >= 3 {
-				patchVersion, _ = strconv.ParseInt(parts[2], 0, 64)
-			}
-		}
+	majorVersion, err := convertVersionPiece(parts, 0)
+	if err != nil {
+		log.Debugf("Error when parsing majorVersion %d: %v", majorVersion, err)
+	}
+	minorVersion, err := convertVersionPiece(parts, 1)
+	if err != nil {
+		log.Debugf("Error when parsing minorVersion %d: %v", minorVersion, err)
+	}
+	patchVersion, err := convertVersionPiece(parts, 2)
+	if err != nil {
+		log.Debugf("Error when parsing patchVersion %d: %v", patchVersion, err)
 	}
 
-	// Maybe we just require people format it with the build number? 
+	// Sometimes a patchVersion can represent a subVersion
+	// e.g.: java:8.252.09 instead of java:8.252+09
+	if majorVersion != 11 && majorVersion != 14 && subVersion == "" && patchVersion > 0 && patchVersion < 100 {
+		subVersion = fmt.Sprintf("%02d", patchVersion)
+	}
+
+	log.Debugf("majorVersion: %d, minorVersion: %d, patchVersion: %d, subVersion: %s",
+		majorVersion, minorVersion, patchVersion, subVersion)
+
+	// Maybe we just require people format it with the build number?
 	// Alternatively we can have a table of defaults somewhere
 	if subVersion == "" {
 		switch majorVersion {
@@ -67,7 +74,7 @@ func NewJavaBuildTool(toolSpec BuildToolSpec) JavaBuildTool {
 		case 12:
 			subVersion = "10"
 		case 13:
-			subVersion = "8"
+			subVersion = "9"
 		case 14:
 			subVersion = "36"
 		default:
@@ -75,21 +82,16 @@ func NewJavaBuildTool(toolSpec BuildToolSpec) JavaBuildTool {
 		}
 	}
 
-
 	tool := JavaBuildTool{
-		version: toolSpec.Version,
+		version:      toolSpec.Version,
 		majorVersion: majorVersion,
 		minorVersion: minorVersion,
 		patchVersion: patchVersion,
-		subVersion: subVersion,
-		spec:    toolSpec,
+		subVersion:   subVersion,
+		spec:         toolSpec,
 	}
 
 	return tool
-}
-
-func (bt JavaBuildTool) Version() string {
-	return bt.version
 }
 
 func (bt JavaBuildTool) InstallDir() string {
@@ -110,9 +112,24 @@ func (bt JavaBuildTool) JavaDir() string {
 
 	if opsys == "darwin" {
 		basePath = filepath.Join(basePath, "Contents", "Home")
-	}
 
+	}
 	return basePath
+}
+
+func convertVersionPiece(parts []string, index int) (piece int64, err error) {
+	if len(parts) >= index+1 {
+		trimmed := strings.TrimLeft(parts[index], "0")
+		piece, err = strconv.ParseInt(trimmed, 0, 64)
+		if err != nil {
+			err = fmt.Errorf("failed to parse %s: %v", parts[index], err)
+		}
+	}
+	return
+}
+
+func (bt JavaBuildTool) Version() string {
+	return bt.version
 }
 
 func (bt JavaBuildTool) Setup() error {
@@ -131,19 +148,25 @@ func (bt JavaBuildTool) Setup() error {
 func (bt JavaBuildTool) DownloadUrl() string {
 
 	// This changes pretty dramatically depending on major version :~(
-    // Using HotSpot version, we should consider an OpenJ9 option 
+	// Using HotSpot version, we should consider an OpenJ9 option
 	urlPattern := ""
 	if bt.majorVersion < 9 {
+		// TODO add openjdk8 OpenJ9 support
 		urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{.MajorVersion}}-binaries/releases/download/jdk{{.MajorVersion}}u{{.MinorVersion}}-b{{.SubVersion}}/OpenJDK{{.MajorVersion}}U-jdk_{{.Arch}}_{{.OS}}_hotspot_{{.MajorVersion}}u{{.MinorVersion}}b{{.SubVersion}}.{{.Extension}}"
 	} else {
 		if bt.majorVersion < 14 {
-			urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}.{{ .MinorVersion }}.{{ .PatchVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_x64_linux_hotspot_{{ .MajorVersion }}.{{ .MinorVersion }}.{{ .PatchVersion }}_{{ .SubVersion }}.{{ .Extension }}"
+			// OpenJDK 9 has a whole other scheme
+			if bt.majorVersion == 9 && bt.subVersion == "181" {
+				urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_{{.Arch}}_{{.OS}}_hotspot_{{ .MajorVersion }}_{{ .SubVersion }}.{{ .Extension }}"
+			} else {
+				urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}.{{ .MinorVersion }}.{{ .PatchVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_{{.Arch}}_{{.OS}}_hotspot_{{ .MajorVersion }}.{{ .MinorVersion }}.{{ .PatchVersion }}_{{ .SubVersion }}.{{ .Extension }}"
+			}
 		} else {
 			// 14: https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_aarch64_linux_hotspot_14_36.tar.gz
-			urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_x64_linux_hotspot_{{ .MajorVersion }}_{{ .SubVersion }}.{{ .Extension }}"
+			urlPattern = "https://github.com/AdoptOpenJDK/openjdk{{ .MajorVersion }}-binaries/releases/download/jdk-{{ .MajorVersion }}%2B{{ .SubVersion }}/OpenJDK{{ .MajorVersion }}U-jdk_{{.Arch}}_{{.OS}}_hotspot_{{ .MajorVersion }}_{{ .SubVersion }}.{{ .Extension }}"
 		}
 	}
-	
+
 	arch := "x64"
 	extension := "tar.gz"
 
@@ -162,7 +185,7 @@ func (bt JavaBuildTool) DownloadUrl() string {
 		MajorVersion int64
 		MinorVersion int64
 		PatchVersion int64
-		SubVersion   string // not always an int, sometimes a float 
+		SubVersion   string // not always an int, sometimes a float
 		Extension    string
 	}{
 		operatingSystem,

--- a/buildpacks/openjdk_test.go
+++ b/buildpacks/openjdk_test.go
@@ -3,38 +3,87 @@ package buildpacks
 import "testing"
 
 func TestOpenJDKUrlGeneration(t *testing.T) {
+	// NOTE This can go on forever, so we better come up with a generic and reliable way of keep tools versions up to date
 	for _, data := range []struct {
 		version string
-		url string
-	}{ 
-		{ 
+		url     string
+	}{
+		{
+			version: "9+181",
+			url:     "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk-9%2B181/OpenJDK9U-jdk_x64_linux_hotspot_9_181.tar.gz",
+		},
+		{
+			version: "8.252+09",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u252b09.tar.gz",
+		},
+		{
+			version: "8.252.9",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u252b09.tar.gz",
+		},
+		{
+			version: "8.252.09",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u252b09.tar.gz",
+		},
+		{
+			version: "8.242+08",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
+		},
+		{
+			version: "8.242.8",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
+		},
+		{
 			version: "8.242.08",
-			url: "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
 		},
 		{
-			version: "11.0.6", 
-			url: "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz",
-		},
- 	  {
-			version: "11.0.6+10", 
-			url: "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz",
+			version: "8.232+09",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz",
 		},
 		{
-			version: "14", 
-			url: "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz",
+			version: "8.232.09",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz",
 		},
-		{ 
+		{
+			version: "8.232.9",
+			url:     "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz",
+		},
+		{
+			version: "11.0.6",
+			url:     "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz",
+		},
+		{
+			version: "11.0.6+10",
+			url:     "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz",
+		},
+		{
+			version: "12.0.2+10",
+			url:     "https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jdk_x64_linux_hotspot_12.0.2_10.tar.gz",
+		},
+		{
+			version: "13.0.2+8",
+			url:     "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_x64_linux_hotspot_13.0.2_8.tar.gz",
+		},
+		{
+			version: "13.0.1+9",
+			url:     "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9/OpenJDK13U-jdk_x64_linux_hotspot_13.0.1_9.tar.gz",
+		},
+		{
+			version: "14",
+			url:     "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz",
+		},
+		{
 			version: "14+36",
-			url: "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz",
+			url:     "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz",
 		},
 	} {
-		bt := NewJavaBuildTool(BuildToolSpec{ Tool: "java", Version: data.version, SharedCacheDir: "/tmp/ybcache", PackageCacheDir: "/tmp/pkgcache", PackageDir: "/opt/tools/java" })
+		bt := NewJavaBuildTool(BuildToolSpec{Tool: "java", Version: data.version, SharedCacheDir: "/tmp/ybcache", PackageCacheDir: "/tmp/pkgcache", PackageDir: "/opt/tools/java"})
 
 		url := bt.DownloadUrl()
-		wanted := data.url 
+		wanted := data.url
 
 		if url != wanted {
-			t.Errorf("Wanted: '%s'; got '%s'", wanted, url)
+			t.Errorf("Wanted:\n'%s'; got:\n'%s'", wanted, url)
 		}
 	}
 }

--- a/buildpacks/python.go
+++ b/buildpacks/python.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	anacondaToolVersion = "4.8.3"
-	anacondaURLTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
+	// The version above needs a newer template
+	anacondaURLTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-py37_{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
 )
 
 type PythonBuildTool struct {
@@ -113,7 +114,7 @@ func (bt PythonBuildTool) DownloadUrl() string {
 		3,
 		opsys,
 		arch,
-		AnacondaToolVersion,
+		anacondaToolVersion,
 		extension,
 	}
 

--- a/buildpacks/python.go
+++ b/buildpacks/python.go
@@ -10,6 +10,11 @@ import (
 	. "github.com/yourbase/yb/types"
 )
 
+const (
+	anacondaToolVersion = "4.8.3"
+	anacondaURLTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
+)
+
 type PythonBuildTool struct {
 	BuildTool
 	version string
@@ -17,8 +22,6 @@ type PythonBuildTool struct {
 }
 
 var ANACONDA_URL_TEMPLATE = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
-
-const AnacondaToolVersion = "4.7.10"
 
 func NewPythonBuildTool(toolSpec BuildToolSpec) PythonBuildTool {
 	tool := PythonBuildTool{
@@ -34,7 +37,7 @@ func (bt PythonBuildTool) Version() string {
 }
 
 func (bt PythonBuildTool) AnacondaInstallDir() string {
-	return filepath.Join(bt.spec.SharedCacheDir, "miniconda3", fmt.Sprintf("miniconda-%s", AnacondaToolVersion))
+	return filepath.Join(bt.spec.SharedCacheDir, "miniconda3", fmt.Sprintf("miniconda-%s", anacondaToolVersion))
 }
 
 func (bt PythonBuildTool) EnvironmentDir() string {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/Microsoft/hcsshim v0.8.9 // indirect
 	github.com/beholders-eye/diffparser v0.0.0-20190814025112-fcedf0a097ba
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/containerd v1.4.0 // indirect
 	github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,9 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beholders-eye/diffparser v0.0.0-20190814025112-fcedf0a097ba h1:cmh1vtyJtZtPcoLissi5rpobvQlXcoOlTratoqM1hg4=
 github.com/beholders-eye/diffparser v0.0.0-20190814025112-fcedf0a097ba/go.mod h1:jzq47XEg545Xz8V+iS6XMc0ajIfbrKVBqW/CdP9YEqs=
+github.com/blang/semver v1.1.0 h1:ol1rO7QQB5uy7umSNV7VAmLugfLRD+17sYJujRNYPhg=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
From changes bellow
- Fixes to how we download OpenJDK versions (#104)
- Python build pack: Anaconda version bump: 4.8.3 (#107)
- Anaconda uses a new versioning scheme


But working on Stable
