### PR TITLE
AWS CLI (latest and v2.x.x) buildpack (next)

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -12,6 +12,7 @@ build_targets:
     build_after:
       - default
     commands:
+      - bash -c "cd integration-tests; ../yb build -no-container awscli"
       - apt-get install -y git
       - bash -c "cd integration-tests; ../yb build -no-container"
       - bash -c "cd integration-tests; ../yb build -no-container python"
@@ -28,6 +29,7 @@ build_targets:
     commands:
       - apt-get update
       - apt-get install -y --no-install-recommends zip
+      # TODO(ch2493): Use the awscli build pack instead of Python
       - pip install awscli
       - bash package.sh
       - bash release.sh 

--- a/buildpacks/awscli.go
+++ b/buildpacks/awscli.go
@@ -1,0 +1,169 @@
+package buildpacks
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/yourbase/yb/plumbing/log"
+	"github.com/yourbase/yb/runtime"
+)
+
+type AWSCLIBuildTool struct {
+	version string
+	spec    BuildToolSpec
+}
+
+func NewAWSCLIBuildTool(toolSpec BuildToolSpec) AWSCLIBuildTool {
+	tool := AWSCLIBuildTool{
+		version: toolSpec.Version,
+		spec:    toolSpec,
+	}
+
+	return tool
+}
+
+func (bt AWSCLIBuildTool) ArchiveFile() string {
+	pkgName := "awscli-exe"
+	os := bt.spec.InstallTarget.OS()
+	arch := bt.spec.InstallTarget.Architecture()
+	osPart := "-linux"
+	architecture := "-x86_64"
+	ext := "zip"
+	v := bt.Version()
+
+	// awscli-exe-linux-x86_64-%s.zip for a specific version, e.g.: 2.0.49 (latest)
+	// or awscli-exe-linux-x86_64.zip for the latest
+
+	if os == runtime.Darwin {
+		osPart = ""
+		architecture = ""
+		pkgName = "AWSCLIV2"
+		ext = "pkg"
+	} else if os == runtime.Windows {
+		// TODO add support for Windows (for the whole CLI?)
+		// dig http://stackoverflow.com/questions/8560166/ddg#8560308 for unattended MSI installs
+		return ""
+	}
+
+	// TODO support arm64, armv6
+	if arch != runtime.Amd64 {
+		return ""
+	}
+
+	base := pkgName + osPart + architecture
+
+	if v == "latest" {
+		return base + "." + ext
+	}
+
+	return base + "-" + v + "." + ext
+}
+
+func (bt AWSCLIBuildTool) DownloadURL(ctx context.Context) (string, error) {
+	// This version of the AWS CLI has a bundled-in Python, it will be Linux only for now
+	const awsCLIBaseURL = "https://awscli.amazonaws.com/"
+	archiveFile := bt.ArchiveFile()
+	if archiveFile == "" {
+		return "", fmt.Errorf("no support for arch/OS yet")
+	}
+
+	return awsCLIBaseURL + archiveFile, nil
+}
+
+func (bt AWSCLIBuildTool) Version() string {
+	return bt.version
+}
+
+func (bt AWSCLIBuildTool) Install(ctx context.Context) (string, error) {
+	t := bt.spec.InstallTarget
+
+	installDir := filepath.Join(t.ToolsDir(ctx), "awscli", bt.Version())
+
+	if t.PathExists(ctx, installDir) {
+		log.Infof("AWSCLI v%s located in %s!", bt.Version(), installDir)
+		return installDir, nil
+	}
+	log.Infof("Will install AWSCLI v%s into %s", bt.Version(), installDir)
+
+	downloadURL, err := bt.DownloadURL(ctx)
+	if err != nil {
+		log.Errorf("Unable to generate download URL: %v", err)
+		return "", err
+	}
+
+	log.Infof("Downloading from URL %s ...", downloadURL)
+	localFile, err := t.DownloadFile(ctx, downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v", err)
+		return "", err
+	}
+
+	if bt.spec.InstallTarget.OS() == runtime.Darwin {
+		return bt.darwinInstall(ctx, installDir)
+	}
+
+	err = t.Unarchive(ctx, localFile, installDir)
+	if err != nil {
+		log.Errorf("Unable to decompress: %v", err)
+		return "", err
+	}
+
+	return installDir, nil
+}
+
+func (bt AWSCLIBuildTool) darwinInstall(ctx context.Context, installDir string) (string, error) {
+	log.Warnf("Installing AWSCLI on Darwin is only supported in Metal")
+
+	customPkgXMLPath := filepath.Join(installDir, "choices.xml")
+
+	customPkgXML := fmt.Sprintf(`
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <dict>
+      <key>choiceAttribute</key>
+      <string>customLocation</string>
+      <key>attributeSetting</key>
+      <string>%s</string>
+      <key>choiceIdentifier</key>
+      <string>default</string>
+    </dict>
+  </array>
+</plist>
+`, customPkgXMLPath)
+
+	t := bt.spec.InstallTarget
+	err := t.WriteFileContents(ctx, customPkgXML, customPkgXMLPath)
+	if err != nil {
+		return "", err
+	}
+
+	err = t.Run(ctx, runtime.Process{
+		Command: "installer -pkg " + bt.ArchiveFile() + " -target " + installDir + " -applyChoiceChangesXML choices.xml",
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return installDir, nil
+}
+
+func (bt AWSCLIBuildTool) Setup(ctx context.Context, installDir string) error {
+	t := bt.spec.InstallTarget
+
+	t.PrependToPath(ctx, filepath.Join(installDir, "bin"))
+
+	cmd := "aws --version"
+	log.Infof("Running: %v", cmd)
+	err := t.Run(ctx, runtime.Process{
+		Command:   cmd,
+		Directory: bt.spec.PackageDir,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/buildpacks/awscli.go
+++ b/buildpacks/awscli.go
@@ -109,9 +109,31 @@ func (bt AWSCLIBuildTool) Install(ctx context.Context) (string, error) {
 		return "", err
 	}
 
+	var updateString string
+	if bt.Version() == "latest" {
+		updateString = "--update "
+	}
+
+	// Linux installation
+	// NOTE Needs to be run as root (sudo)
+	for _, cmd := range []string{
+		"mkdir -p bin",
+		"./aws/install " + updateString + "--install-dir " + installDir + " --bin-dir ./bin",
+	} {
+		err = t.Run(ctx, runtime.Process{
+			Command:   cmd,
+			Directory: installDir,
+		})
+		if err != nil {
+			return "", err
+		}
+	}
+
 	return installDir, nil
 }
 
+// darwinInstall is a branch from Install, that will do rootless AWSCLIv2 install on a Mac OS X
+// NOTE: this needs the equivalent of Travis's Matrix support for our YAML, to be tested on the CI
 func (bt AWSCLIBuildTool) darwinInstall(ctx context.Context, installDir string) (string, error) {
 	log.Warnf("Installing AWSCLI on Darwin is only supported in Metal")
 

--- a/buildpacks/awscli_test.go
+++ b/buildpacks/awscli_test.go
@@ -1,0 +1,89 @@
+package buildpacks
+
+import (
+	"context"
+	goruntime "runtime"
+	"testing"
+
+	"github.com/yourbase/yb/runtime"
+)
+
+func TestAWSCLIBuildTool_DownloadURL(t *testing.T) {
+	type testCall struct {
+		name    string
+		version string
+		URL     string
+		wantErr bool
+	}
+
+	var tests []testCall
+
+	if goruntime.GOOS == "linux" {
+		tests = []testCall{
+			{
+				name:    "latest",
+				version: "latest",
+				URL:     "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip",
+			},
+			{
+				name:    "version 2.0.49",
+				version: "2.0.49",
+				URL:     "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.49.zip",
+			},
+			{
+				name:    "version 2.0.41",
+				version: "2.0.41",
+				URL:     "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.41.zip",
+			},
+			{
+				name:    "version 2.0.30",
+				version: "2.0.30",
+				URL:     "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip",
+			},
+		}
+	} else if goruntime.GOOS == "darwin" {
+		tests = []testCall{
+			{
+				name:    "latest",
+				version: "latest",
+				URL:     "https://awscli.amazonaws.com/AWSCLIV2.pkg",
+			},
+			{
+				name:    "version 2.0.49",
+				version: "2.0.49",
+				URL:     "https://awscli.amazonaws.com/AWSCLIV2-2.0.49.pkg",
+			},
+			{
+				name:    "version 2.0.41",
+				version: "2.0.41",
+				URL:     "https://awscli.amazonaws.com/AWSCLIV2-2.0.41.pkg",
+			},
+			{
+				name:    "version 2.0.30",
+				version: "2.0.30",
+				URL:     "https://awscli.amazonaws.com/AWSCLIV2-2.0.30.pkg",
+			},
+		}
+	} else if goruntime.GOOS == "windows" || goruntime.GOARCH != "amd64" {
+		tests = []testCall{
+			{
+				name:    "failed for unsupported Architecture",
+				wantErr: true,
+			},
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bt := NewAWSCLIBuildTool(BuildToolSpec{Tool: "awscli", Version: tt.version, PackageDir: "/opt/tools/awscli"})
+			bt.spec.InstallTarget = &runtime.MetalTarget{}
+			gotURL, err := bt.DownloadURL(context.Background())
+			if !tt.wantErr && err != nil {
+				t.Fatalf("Unable to generate download URL: %V", err)
+			}
+			if gotURL != tt.URL {
+				t.Errorf("AWSCLIBuildTool.DownloadURL() = %v, want %v", gotURL, tt.URL)
+			}
+		})
+	}
+}

--- a/integration-tests/.yourbase.yml
+++ b/integration-tests/.yourbase.yml
@@ -4,10 +4,12 @@
 #
 build_targets:
   - name: default
+    host_only: true
     commands:
       - git submodule update --checkout --depth 2
 
   - name: python
+    host_only: true
     commands:
       - cp python/.yourbase.flask.yml python/flask/.yourbase.yml
       - cp python/.yourbase.httpie.yml python/httpie/.yourbase.yml
@@ -15,6 +17,7 @@ build_targets:
       - bash -c "cd python/httpie && ../../../yb build -no-container default; git clean -f ."
 
   - name: java
+    host_only: true
     commands:
       - cp java/.yourbase.RxJava.yml java/RxJava/.yourbase.yml
       - cp java/.yourbase.guava.yml java/guava/.yourbase.yml
@@ -24,6 +27,7 @@ build_targets:
       - bash -c "cd java/java-design-patterns && ../../../yb build -no-container default; git clean -f ."
 
   - name: gopher
+    host_only: true
     commands:
       - cp go/.yourbase.gg.yml go/gg/.yourbase.yml
       - cp go/.yourbase.gin.yml go/gin/.yourbase.yml
@@ -31,6 +35,7 @@ build_targets:
       - bash -c "cd go/gin && ../../../yb build -no-container default; git clean -f ."
 
   - name: ruby
+    host_only: true
     commands:
       - cp ruby/.yourbase.capistrano.yml ruby/capistrano/.yourbase.yml
       - cp ruby/.yourbase.devise.yml ruby/devise/.yourbase.yml
@@ -38,8 +43,15 @@ build_targets:
       - bash -c "cd ruby/devise && ../../../yb build -no-container default; git clean -f ."
 
   - name: flutter
+    host_only: true
     commands:
       - cp flutter/.yourbase.flutter-examples.yml flutter/flutter-examples/.yourbase.yml
       - cp flutter/.yourbase.pin_code_test_field.yml flutter/pin_code_test_field/.yourbase.yml
       - bash -c "cd flutter/flutter-examples && ../../../yb build -no-container default; git clean -f ."
       - bash -c "cd flutter/pin_code_test_field && ../../../yb build -no-container default; git clean -f ."
+
+  - name: awscli
+    host_only: true
+    commands:
+      - bash -c "cd awscli-testground && ../../yb build -no-container default"
+      - bash -c "cd awscli-testground && ../../yb build -no-container v2.x"

--- a/integration-tests/awscli-testground/.yourbase.yml
+++ b/integration-tests/awscli-testground/.yourbase.yml
@@ -1,0 +1,16 @@
+build_targets:
+  - name: default
+    host_only: true
+    dependencies:
+      build:
+        - awscli:latest
+    commands:
+    - aws --version
+
+  - name: v2.x
+    host_only: true
+    dependencies:
+      build:
+        - awscli:2.0.49
+    commands:
+    - aws --version

--- a/workspace/buildpack_loader.go
+++ b/workspace/buildpack_loader.go
@@ -39,6 +39,8 @@ func LoadBuildPacks(ctx context.Context, installTarget runtime.Target, dependenc
 			bt = buildpacks.NewAnaconda3BuildTool(spec)
 		case "ant":
 			bt = buildpacks.NewAntBuildTool(spec)
+		case "awscli":
+			bt = buildpacks.NewAWSCLIBuildTool(spec)
 		case "r":
 			bt = buildpacks.NewRLangBuildTool(spec)
 		case "heroku":


### PR DESCRIPTION
This is mostly internal. But can benefit whoever needs to use AWS CLI on
his/her project.

Add a build pack to download the binary distribution of AWS CLI tool,
that comes with a bundled Python binary distribution

Helps with [ch2493] -- ch-2493
