### PR TITLE
AWS CLI (latest and v2.x.x) buildpack (main)

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -12,6 +12,7 @@ build_targets:
     build_after:
       - default
     commands:
+      - bash -c "cd integration-tests; ../yb build -no-container awscli"
       - apt-get install -y --no-install-recommends git
       - bash -c "cd integration-tests; ../yb build -no-container"
       - bash -c "cd integration-tests; ../yb build -no-container flutter"
@@ -29,6 +30,7 @@ build_targets:
     commands:
       - apt-get update
       - apt-get install -y --no-install-recommends zip
+      # TODO(ch2493): Use the awscli build pack instead of Python
       - pip install awscli
       - bash package.sh
       - bash release.sh 

--- a/buildpacks/awscli.go
+++ b/buildpacks/awscli.go
@@ -1,0 +1,124 @@
+package buildpacks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/plumbing"
+	"github.com/yourbase/yb/plumbing/log"
+)
+
+type AWSCLIBuildTool struct {
+	version string
+	spec    BuildToolSpec
+}
+
+func NewAWSCLIBuildTool(toolSpec BuildToolSpec) AWSCLIBuildTool {
+	tool := AWSCLIBuildTool{
+		version: toolSpec.Version,
+		spec:    toolSpec,
+	}
+
+	return tool
+}
+
+func (bt AWSCLIBuildTool) ArchiveFile() string {
+	pkgName := "awscli-exe"
+	os := OS()
+	arch := Arch()
+	osPart := "-linux"
+	architecture := "-x86_64"
+	ext := "zip"
+	v := bt.Version()
+
+	// awscli-exe-linux-x86_64-%s.zip for a specific version, e.g.: 2.0.49 (latest)
+	// or awscli-exe-linux-x86_64.zip for the latest
+
+	if os == "darwin" {
+		osPart = ""
+		architecture = ""
+		pkgName = "AWSCLIV2"
+		ext = "pkg"
+	} else if os == "windows" {
+		// TODO add support for Windows (for the whole CLI?)
+		// dig http://stackoverflow.com/questions/8560166/ddg#8560308 for unattended MSI installs
+		return ""
+	}
+
+	// TODO support arm64, armv6
+	if arch != "amd64" {
+		return ""
+	}
+
+	base := pkgName + osPart + architecture
+
+	if v == "latest" {
+		return base + "." + ext
+	}
+
+	return base + "-" + v + "." + ext
+}
+
+func (bt AWSCLIBuildTool) DownloadURL() string {
+	// This version of the AWS CLI has a bundled-in Python, it will be Linux only for now
+	const awsCLIBaseURL = "https://awscli.amazonaws.com/"
+	archiveFile := bt.ArchiveFile()
+	if archiveFile == "" {
+		return ""
+	}
+
+	return awsCLIBaseURL + archiveFile
+}
+
+func (bt AWSCLIBuildTool) InstallDir() string {
+	return filepath.Join(bt.spec.SharedCacheDir, "awscli", bt.Version())
+}
+
+func (bt AWSCLIBuildTool) Version() string {
+	return bt.version
+}
+
+func (bt AWSCLIBuildTool) Install() error {
+	installDir := bt.InstallDir()
+
+	if _, err := os.Stat(installDir); err == nil {
+		log.Infof("AWSCLI v%s located in %s!", bt.Version(), installDir)
+		return nil
+	}
+
+	log.Infof("Will install AWSCLI v%s into %s", bt.Version(), installDir)
+	downloadURL := bt.DownloadURL()
+	log.Infof("Downloading from URL %s ...", downloadURL)
+	localFile, err := plumbing.DownloadFileWithCache(downloadURL)
+	if err != nil {
+		log.Errorf("Unable to download: %v", err)
+		return err
+	}
+
+	if OS() == "darwin" {
+		return fmt.Errorf("Work in progress, please try v0.2.x")
+	}
+
+	err = archiver.Unarchive(localFile, installDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (bt AWSCLIBuildTool) Setup() error {
+
+	plumbing.PrependToPath(filepath.Join(bt.InstallDir(), "bin"))
+
+	cmd := "aws --version"
+	log.Infof("Running: %v", cmd)
+	err := plumbing.ExecToStdout(cmd, bt.InstallDir())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/buildpacks/awscli.go
+++ b/buildpacks/awscli.go
@@ -112,7 +112,6 @@ func (bt AWSCLIBuildTool) Install() error {
 	}
 
 	// Linux installation
-	// NOTE Needs to be run as root (sudo)
 	for _, cmd := range []string{
 		"mkdir -p bin",
 		"./aws/install " + updateString + "--install-dir " + installDir + " --bin-dir ./bin",

--- a/buildpacks/awscli_test.go
+++ b/buildpacks/awscli_test.go
@@ -1,0 +1,82 @@
+package buildpacks
+
+import (
+	goruntime "runtime"
+	"testing"
+)
+
+func TestAWSCLIBuildTool_DownloadURL(t *testing.T) {
+	type testCall struct {
+		name    string
+		version string
+		URL     string
+		wantErr bool
+	}
+
+	var tests []testCall
+
+	if goruntime.GOOS == "linux" {
+		tests = []testCall{
+			{
+				name:    "latest",
+				version: "latest",
+				URL:     "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip",
+			},
+			{
+				name:    "version 2.0.49",
+				version: "2.0.49",
+				URL:     "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.49.zip",
+			},
+			{
+				name:    "version 2.0.41",
+				version: "2.0.41",
+				URL:     "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.41.zip",
+			},
+			{
+				name:    "version 2.0.30",
+				version: "2.0.30",
+				URL:     "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip",
+			},
+		}
+	} else if goruntime.GOOS == "darwin" {
+		tests = []testCall{
+			{
+				name:    "latest",
+				version: "latest",
+				URL:     "https://awscli.amazonaws.com/AWSCLIV2.pkg",
+			},
+			{
+				name:    "version 2.0.49",
+				version: "2.0.49",
+				URL:     "https://awscli.amazonaws.com/AWSCLIV2-2.0.49.pkg",
+			},
+			{
+				name:    "version 2.0.41",
+				version: "2.0.41",
+				URL:     "https://awscli.amazonaws.com/AWSCLIV2-2.0.41.pkg",
+			},
+			{
+				name:    "version 2.0.30",
+				version: "2.0.30",
+				URL:     "https://awscli.amazonaws.com/AWSCLIV2-2.0.30.pkg",
+			},
+		}
+	} else if goruntime.GOOS == "windows" || goruntime.GOARCH != "amd64" {
+		tests = []testCall{
+			{
+				name:    "failed for unsupported Architecture",
+				wantErr: true,
+			},
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bt := NewAWSCLIBuildTool(BuildToolSpec{Tool: "awscli", Version: tt.version, PackageDir: "/opt/tools/awscli"})
+			gotURL := bt.DownloadURL()
+			if gotURL != tt.URL {
+				t.Errorf("AWSCLIBuildTool.DownloadURL() = %v, want %v", gotURL, tt.URL)
+			}
+		})
+	}
+}

--- a/buildpacks/buildpack_loader.go
+++ b/buildpacks/buildpack_loader.go
@@ -47,6 +47,8 @@ func LoadBuildPacks(dependencies []string, pkgCacheDir string, pkgDir string) ([
 			bt = NewAnaconda3BuildTool(spec)
 		case "ant":
 			bt = NewAntBuildTool(spec)
+		case "awscli":
+			bt = NewAWSCLIBuildTool(spec)
 		case "r":
 			bt = NewRLangBuildTool(spec)
 		case "heroku":

--- a/integration-tests/.yourbase.yml
+++ b/integration-tests/.yourbase.yml
@@ -3,10 +3,12 @@
 #
 build_targets:
   - name: default
+    host_only: true
     commands:
       - git submodule update --checkout --depth 2
 
   - name: python
+    host_only: true
     commands:
       - cp python/.yourbase.flask.yml python/flask/.yourbase.yml
       - cp python/.yourbase.httpie.yml python/httpie/.yourbase.yml
@@ -14,6 +16,7 @@ build_targets:
       - bash -c "cd python/httpie && ../../../yb build -no-container default; git clean -f ."
 
   - name: java
+    host_only: true
     commands:
       - cp java/.yourbase.RxJava.yml java/RxJava/.yourbase.yml
       - cp java/.yourbase.guava.yml java/guava/.yourbase.yml
@@ -23,6 +26,7 @@ build_targets:
       - bash -c "cd java/java-design-patterns && ../../../yb build -no-container default; git clean -f ."
 
   - name: gopher
+    host_only: true
     commands:
       - cp go/.yourbase.gg.yml go/gg/.yourbase.yml
       - cp go/.yourbase.gin.yml go/gin/.yourbase.yml
@@ -30,6 +34,7 @@ build_targets:
       - bash -c "cd go/gin && ../../../yb build -no-container default; git clean -f ."
 
   - name: ruby
+    host_only: true
     commands:
       - cp ruby/.yourbase.capistrano.yml ruby/capistrano/.yourbase.yml
       - cp ruby/.yourbase.devise.yml ruby/devise/.yourbase.yml
@@ -37,6 +42,7 @@ build_targets:
       - bash -c "cd ruby/devise && ../../../yb build -no-container default; git clean -f ."
 
   - name: flutter
+    host_only: true
     commands:
       - cp flutter/.yourbase.flutter-examples.yml flutter/flutter-examples/.yourbase.yml
       - cp flutter/.yourbase.pin_code_test_field.yml flutter/pin_code_test_field/.yourbase.yml
@@ -44,3 +50,9 @@ build_targets:
       - bash -c "cd flutter/pin_code_test_field && ../../../yb build -no-container default; git clean -f ."
       - bash -c "cd flutter/flutter-examples && ../../../yb build -no-container beta; git clean -f ."
       - bash -c "cd flutter/pin_code_test_field && ../../../yb build -no-container beta; git clean -f ."
+
+  - name: awscli
+    host_only: true
+    commands:
+      - bash -c "cd awscli-testground && ../../yb build -no-container default"
+      - bash -c "cd awscli-testground && ../../yb build -no-container v2.x"

--- a/integration-tests/awscli-testground/.yourbase.yml
+++ b/integration-tests/awscli-testground/.yourbase.yml
@@ -1,0 +1,16 @@
+build_targets:
+  - name: default
+    host_only: true
+    dependencies:
+      build:
+        - awscli:latest
+    commands:
+    - aws --version
+
+  - name: v2.x
+    host_only: true
+    dependencies:
+      build:
+        - awscli:2.0.49
+    commands:
+    - aws --version


### PR DESCRIPTION
Cherry picked from #174

To give more context for code reviewers:

Cherry-picked from #174 which is based on `next` (runtime-context: v0.2.x). In `main` we don't have abstractions to represent the runtime (metal vs. container), instead we use Go's `os` for changing the environment and `exec` to run commands.
That way, after cherry picking, I had to simplify all the logic. I also removed any possible way of running this on "Darwin", for stable. As we mainly release our components inside of Linux build servers. I hope this is OK, for the time being.

Unit tests created for `DownloadURL` only.

Updates [ch2493] -- ch-2493