### PR TITLE
Unexport most of buildpacks package

### DIFF
--- a/buildpacks/dart.go
+++ b/buildpacks/dart.go
@@ -1,6 +1,7 @@
 package buildpacks
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,28 +9,26 @@ import (
 	"github.com/johnewart/archiver"
 	"github.com/yourbase/yb/plumbing"
 	"github.com/yourbase/yb/plumbing/log"
-	"github.com/yourbase/yb/types"
 )
 
 //https://archive.apache.org/dist/dart/dart-3/3.3.3/binaries/apache-dart-3.3.3-bin.tar.gz
-var DART_DIST_MIRROR = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{.Version}}/sdk/dartsdk-{{.OS}}-{{.Arch}}-release.zip"
+const dartDistMirror = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{.Version}}/sdk/dartsdk-{{.OS}}-{{.Arch}}-release.zip"
 
-type DartBuildTool struct {
-	types.BuildTool
+type dartBuildTool struct {
 	version string
-	spec    BuildToolSpec
+	spec    buildToolSpec
 }
 
-func NewDartBuildTool(toolSpec BuildToolSpec) DartBuildTool {
-	tool := DartBuildTool{
-		version: toolSpec.Version,
+func newDartBuildTool(toolSpec buildToolSpec) dartBuildTool {
+	tool := dartBuildTool{
+		version: toolSpec.version,
 		spec:    toolSpec,
 	}
 
 	return tool
 }
 
-func (bt DartBuildTool) DownloadUrl() string {
+func (bt dartBuildTool) downloadURL() string {
 	opsys := OS()
 	arch := Arch()
 	extension := "zip"
@@ -42,7 +41,7 @@ func (bt DartBuildTool) DownloadUrl() string {
 		opsys = "macos"
 	}
 
-	version := bt.Version()
+	version := bt.version
 
 	data := struct {
 		OS        string
@@ -56,30 +55,26 @@ func (bt DartBuildTool) DownloadUrl() string {
 		extension,
 	}
 
-	url, _ := plumbing.TemplateToString(DART_DIST_MIRROR, data)
+	url, _ := plumbing.TemplateToString(dartDistMirror, data)
 
 	return url
 }
 
-func (bt DartBuildTool) MajorVersion() string {
+func (bt dartBuildTool) majorVersion() string {
 	parts := strings.Split(bt.version, ".")
 	return parts[0]
 }
 
-func (bt DartBuildTool) Version() string {
-	return bt.version
+func (bt dartBuildTool) installDir() string {
+	return filepath.Join(bt.spec.sharedCacheDir, "dart", bt.version)
 }
 
-func (bt DartBuildTool) InstallDir() string {
-	return filepath.Join(bt.spec.SharedCacheDir, "dart", bt.Version())
+func (bt dartBuildTool) dartDir() string {
+	return filepath.Join(bt.installDir(), "dart-sdk")
 }
 
-func (bt DartBuildTool) DartDir() string {
-	return filepath.Join(bt.InstallDir(), "dart-sdk")
-}
-
-func (bt DartBuildTool) Setup() error {
-	dartDir := bt.DartDir()
+func (bt dartBuildTool) setup(ctx context.Context) error {
+	dartDir := bt.dartDir()
 	cmdPath := filepath.Join(dartDir, "bin")
 	plumbing.PrependToPath(cmdPath)
 
@@ -87,15 +82,15 @@ func (bt DartBuildTool) Setup() error {
 }
 
 // TODO, generalize downloader
-func (bt DartBuildTool) Install() error {
-	dartDir := bt.DartDir()
-	installDir := bt.InstallDir()
+func (bt dartBuildTool) install(ctx context.Context) error {
+	dartDir := bt.dartDir()
+	installDir := bt.installDir()
 
 	if _, err := os.Stat(dartDir); err == nil {
-		log.Infof("Dart v%s located in %s!", bt.Version(), dartDir)
+		log.Infof("Dart v%s located in %s!", bt.version, dartDir)
 	} else {
-		log.Infof("Will install Dart v%s into %s", bt.Version(), dartDir)
-		downloadUrl := bt.DownloadUrl()
+		log.Infof("Will install Dart v%s into %s", bt.version, dartDir)
+		downloadUrl := bt.downloadURL()
 
 		log.Infof("Downloading Dart from URL %s...", downloadUrl)
 		localFile, err := plumbing.DownloadFileWithCache(downloadUrl)

--- a/buildpacks/openjdk_test.go
+++ b/buildpacks/openjdk_test.go
@@ -77,9 +77,9 @@ func TestOpenJDKUrlGeneration(t *testing.T) {
 			url:     "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36/OpenJDK14U-jdk_x64_linux_hotspot_14_36.tar.gz",
 		},
 	} {
-		bt := NewJavaBuildTool(BuildToolSpec{Tool: "java", Version: data.version, SharedCacheDir: "/tmp/ybcache", PackageCacheDir: "/tmp/pkgcache", PackageDir: "/opt/tools/java"})
+		bt := newJavaBuildTool(buildToolSpec{tool: "java", version: data.version, sharedCacheDir: "/tmp/ybcache", packageCacheDir: "/tmp/pkgcache", packageDir: "/opt/tools/java"})
 
-		url := bt.DownloadUrl()
+		url := bt.downloadURL()
 		wanted := data.url
 
 		if url != wanted {

--- a/packages/package.go
+++ b/packages/package.go
@@ -86,11 +86,24 @@ func (p Package) BuildRoot() string {
 }
 
 func (p Package) SetupBuildDependencies(ctx context.Context, target types.BuildTarget) error {
-	return buildpacks.LoadBuildPacks(ctx, target.Dependencies.Build, p.BuildRoot(), p.Path)
+	for _, dep := range target.Dependencies.Build {
+		if err := buildpacks.Install(ctx, p.BuildRoot(), p.Path, dep); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (p Package) SetupRuntimeDependencies(ctx context.Context) error {
-	deps := p.Manifest.Dependencies.Runtime
-	deps = append(deps[:len(deps):len(deps)], p.Manifest.Dependencies.Build...)
-	return buildpacks.LoadBuildPacks(ctx, deps, p.BuildRoot(), p.Path)
+	for _, dep := range p.Manifest.Dependencies.Runtime {
+		if err := buildpacks.Install(ctx, p.BuildRoot(), p.Path, dep); err != nil {
+			return err
+		}
+	}
+	for _, dep := range p.Manifest.Dependencies.Build {
+		if err := buildpacks.Install(ctx, p.BuildRoot(), p.Path, dep); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -114,9 +114,3 @@ type WorktreeSave struct {
 	Files   []string
 	Enabled bool
 }
-
-type BuildTool interface {
-	Install() error
-	Setup() error
-	Version() string
-}


### PR DESCRIPTION
Other parts of the codebase only use buildpacks to install a buildpack, so I've unexported these parts to make their purpose clearer and unlock more aggressive refactorings in the future.