### PR TITLE
Add `yb token` command

### DIFF
--- a/cli/token.go
+++ b/cli/token.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/johnewart/subcommands"
+	"github.com/yourbase/yb/config"
+	"github.com/yourbase/yb/plumbing/log"
+)
+
+// TokenCmd represents an invocation of `yb token`, which outputs the saved
+// token from `yb login` to stdout. This can be used
+type TokenCmd struct {
+	Version string
+	Channel string
+}
+
+// Name returns the literal text of the token command.
+func (*TokenCmd) Name() string { return "token" }
+
+// Synopsis returns the shortform description of the token command.
+func (*TokenCmd) Synopsis() string {
+	return "Print an auth token"
+}
+
+// Usage returns usage information for thet token command.
+func (*TokenCmd) Usage() string {
+	return `token
+Prints a YourBase auth token to stdout. Compose this with other tools to make interacting with the YourBase API easier.
+`
+}
+
+// SetFlags describes the flags available to the token command.
+func (p *TokenCmd) SetFlags(f *flag.FlagSet) {
+}
+
+// Execute runs the token command.
+func (p *TokenCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	token, err := config.GetConfigValue("user", "api_key")
+	if err != nil {
+		log.Errorf("Cannot get auth token: %v", err)
+		return subcommands.ExitFailure
+	}
+
+	fmt.Println(token)
+	return subcommands.ExitSuccess
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 	cmdr.Register(&cli.PlatformCmd{}, "")
 	cmdr.Register(&cli.RemoteCmd{}, "")
 	cmdr.Register(&cli.RunCmd{}, "")
+	cmdr.Register(&cli.TokenCmd{}, "")
 	cmdr.Register(&cli.UpdateCmd{}, "")
 	cmdr.Register(&cli.WorkspaceCmd{}, "")
 	cmdr.Register(&cli.VersionCmd{Version: version, Channel: channel, Date: date, CommitSHA: commitSHA}, "")


### PR DESCRIPTION
When developing and testing the API you generally need an auth token. The auth tokens are long enough to cause a single `curl` to span many lines, making it unwieldy to deal with requests. By adding a `yb token` command and inserting it into curl we can get something like
```sh
curl -H "Authorization: Bearer `yb token`" https://api.yourbase.io/users/me
```
instead of something like
```sh
curl -H 'Authorization: Bearer 123bh123bh79h12b1237123hv12b123bvn12873bvn10293vn8127v0129bv3n120v91cv12nbccbn2106bncbvc123bcv201bbcnb12987bncx9128730cb1n2xbnv2523v2v2v23v523v23v23c.v.ewfhwevj1234n9-cv192bnc12blwafvwvfbnvwfab09nwva0bnv9ew8abn8vf09aw6bvwa' https://api.yourbase.io/users/me
```