### PR TITLE
Make command helptext consistent

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -66,7 +66,9 @@ type BuildLog struct {
 func (*BuildCmd) Name() string     { return "build" }
 func (*BuildCmd) Synopsis() string { return "Build the workspace" }
 func (*BuildCmd) Usage() string {
-	return `build`
+	return `Usage: build [TARGET] [OPTIONS]
+Build the project in the current directory. Defaults to the "default" target.
+`
 }
 
 func (b *BuildCmd) SetFlags(f *flag.FlagSet) {

--- a/cli/checkconfig.go
+++ b/cli/checkconfig.go
@@ -15,7 +15,9 @@ type CheckConfigCmd struct {
 func (*CheckConfigCmd) Name() string     { return "checkconfig" }
 func (*CheckConfigCmd) Synopsis() string { return "Check the config file syntax" }
 func (*CheckConfigCmd) Usage() string {
-	return `checkconfig`
+	return `checkconfig [-file FILE]
+Validate the local YourBase config file, .yourbase.yml by default.
+`
 }
 
 func (b *CheckConfigCmd) SetFlags(f *flag.FlagSet) {

--- a/cli/config.go
+++ b/cli/config.go
@@ -20,7 +20,14 @@ type ConfigCmd struct {
 func (*ConfigCmd) Name() string     { return "config" }
 func (*ConfigCmd) Synopsis() string { return "Convenient way to change settings" }
 func (*ConfigCmd) Usage() string {
-	return `config <subcommand>`
+	return `Usage: config get <KEY>
+       config set <KEY> <VALUE>
+Print or change a config variable.
+Keys:
+  environment
+Values:
+  environment: production, staging, preview, development
+`
 }
 
 func (w *ConfigCmd) SetFlags(f *flag.FlagSet) {}

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -22,7 +22,9 @@ func (*ExecCmd) Synopsis() string {
 	return "Execute a project in the workspace, defaults to target project"
 }
 func (*ExecCmd) Usage() string {
-	return `exec [project]`
+	return `Usage: exec [PROJECT]
+Execute a project in the workspace, as specified by .yourbase.yml's exec block.
+`
 }
 
 func (p *ExecCmd) SetFlags(f *flag.FlagSet) {

--- a/cli/login.go
+++ b/cli/login.go
@@ -23,7 +23,9 @@ type LoginCmd struct {
 func (*LoginCmd) Name() string     { return "login" }
 func (*LoginCmd) Synopsis() string { return "Log into YB" }
 func (*LoginCmd) Usage() string {
-	return `login`
+	return `Usage: login
+Configure yb to act as you in the YourBase API.
+`
 }
 
 func (p *LoginCmd) SetFlags(f *flag.FlagSet) {

--- a/cli/platform_info.go
+++ b/cli/platform_info.go
@@ -12,9 +12,11 @@ type PlatformCmd struct {
 }
 
 func (*PlatformCmd) Name() string     { return "platform" }
-func (*PlatformCmd) Synopsis() string { return "Show platform info." }
+func (*PlatformCmd) Synopsis() string { return "Show platform info" }
 func (*PlatformCmd) Usage() string {
-	return `platform`
+	return `Usage: platform
+Show current platform information.
+`
 }
 
 func (p *PlatformCmd) SetFlags(f *flag.FlagSet) {

--- a/cli/remote_build.go
+++ b/cli/remote_build.go
@@ -57,9 +57,11 @@ type RemoteCmd struct {
 }
 
 func (*RemoteCmd) Name() string     { return "remotebuild" }
-func (*RemoteCmd) Synopsis() string { return "Build remotely." }
+func (*RemoteCmd) Synopsis() string { return "Build remotely" }
 func (*RemoteCmd) Usage() string {
-	return "Build remotely using YB infrastructure"
+	return `Usage: remotebuild [TARGET] [OPTIONS]
+Build remotely using YourBase infrastructure. Defaults to the "default" target.
+`
 }
 
 func (p *RemoteCmd) SetFlags(f *flag.FlagSet) {

--- a/cli/run.go
+++ b/cli/run.go
@@ -19,7 +19,9 @@ type RunCmd struct {
 func (*RunCmd) Name() string     { return "run" }
 func (*RunCmd) Synopsis() string { return "Run an arbitrary command" }
 func (*RunCmd) Usage() string {
-	return `run [-e environment] command`
+	return `run [-e ENVIRONMENT] <COMMAND>
+Run a command in the project container.
+`
 }
 
 func (p *RunCmd) SetFlags(f *flag.FlagSet) {

--- a/cli/token.go
+++ b/cli/token.go
@@ -27,8 +27,8 @@ func (*TokenCmd) Synopsis() string {
 
 // Usage returns usage information for thet token command.
 func (*TokenCmd) Usage() string {
-	return `token
-Prints a YourBase auth token to stdout. Compose this with other tools to make interacting with the YourBase API easier.
+	return `Usage: token
+Print a YourBase auth token to stdout. Compose this with other tools to interact with the YourBase API more easily.
 `
 }
 

--- a/cli/token.go
+++ b/cli/token.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/johnewart/subcommands"
+	"github.com/yourbase/yb/config"
+	"github.com/yourbase/yb/plumbing/log"
+)
+
+// TokenCmd represents an invocation of `yb token`, which outputs the saved
+// token from `yb login` to stdout. This can be used
+type TokenCmd struct {
+	Version string
+	Channel string
+}
+
+// Name returns the literal text of the token command.
+func (*TokenCmd) Name() string { return "token" }
+
+// Synopsis returns the shortform description of the token command.
+func (*TokenCmd) Synopsis() string {
+	return "Print an auth token"
+}
+
+// Usage returns usage information for thet token command.
+func (*TokenCmd) Usage() string {
+	return `token
+Prints a YourBase auth token to stdout. Compose this with other tools to make interacting with the YourBase API easier.
+`
+}
+
+// SetFlags describes the flags available to the token command.
+func (p *TokenCmd) SetFlags(f *flag.FlagSet) {
+}
+
+// Execute runs the token command.
+func (p *TokenCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	token, err := config.GetConfigValue("user", "api_key")
+	if err != nil {
+		log.Errorf("Cannot get auth token: %v", err)
+		return subcommands.ExitFailure
+	}
+
+	fmt.Println(token)
+	return subcommands.ExitSuccess
+}

--- a/cli/update.go
+++ b/cli/update.go
@@ -15,9 +15,10 @@ type UpdateCmd struct {
 }
 
 func (*UpdateCmd) Name() string     { return "update" }
-func (*UpdateCmd) Synopsis() string { return "Show update info." }
+func (*UpdateCmd) Synopsis() string { return "Self-update to the latest yb" }
 func (*UpdateCmd) Usage() string {
-	return `update
+	return `Usage: update [OPTIONS]
+Update yb to the latest verison, or a specific version.
 `
 }
 

--- a/cli/version.go
+++ b/cli/version.go
@@ -16,9 +16,11 @@ type VersionCmd struct {
 }
 
 func (*VersionCmd) Name() string     { return "version" }
-func (*VersionCmd) Synopsis() string { return "Show version info." }
+func (*VersionCmd) Synopsis() string { return "Show version info" }
 func (*VersionCmd) Usage() string {
-	return `version`
+	return `Usage: version
+Print the current yb version.
+`
 }
 
 func (p *VersionCmd) SetFlags(f *flag.FlagSet) {

--- a/cli/workspace.go
+++ b/cli/workspace.go
@@ -27,7 +27,9 @@ type WorkspaceCmd struct {
 func (*WorkspaceCmd) Name() string     { return "workspace" }
 func (*WorkspaceCmd) Synopsis() string { return "Workspace-related commands" }
 func (*WorkspaceCmd) Usage() string {
-	return `workspace <subcommand>`
+	return `Usage: workspace <SUBCOMMAND>
+Manage workspaces.
+`
 }
 
 func (w *WorkspaceCmd) SetFlags(f *flag.FlagSet) {}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 	cmdr.Register(&cli.PlatformCmd{}, "")
 	cmdr.Register(&cli.RemoteCmd{}, "")
 	cmdr.Register(&cli.RunCmd{}, "")
+	cmdr.Register(&cli.TokenCmd{}, "")
 	cmdr.Register(&cli.UpdateCmd{}, "")
 	cmdr.Register(&cli.WorkspaceCmd{}, "")
 	cmdr.Register(&cli.VersionCmd{Version: version, Channel: channel, Date: date, CommitSHA: commitSHA}, "")


### PR DESCRIPTION
Makes usage output for commands fuller and more consistent. It's still not perfect, particularly in that the incomplete use of a command, e.g. `yb config` with no additional subcommands, uses a different code path to output usage info (autogenerated) than the direct calling of that command's helptext, e.g. `yb config -help` (manually written). But I punted on diving deeper because of @zombiezen's work ripping out the `subcommands` package.

Consistencies this branch introduces / cements:
- Always start the output of usage info with `Usage: `
- Use `<angle brackets>` for required arguments, `[square brackets]` for optional arguments, and `CAPITALS` for substitutions
- Change all tenses to `Check`/`Validate`/etc. over `Checks`/`Validates`/etc.
- Don't use ending punctuation in shortform command descriptions (those outputted by `yb` or `yb -help`) 
- Follow every usage summary with a longform description of the command
- End usage output with a newline

(This branch is based on #188 since it also updates `yb token`.)
