### PR TITLE
Add Debian binary packaging step to release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,31 @@ jobs:
         asset_path: ./${{ steps.package.outputs.file }}
         asset_name: ${{ steps.package.outputs.file }}
         asset_content_type: application/zip
+  debian:
+    name: Debian
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "^1.15"
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Download dependencies
+      run: go mod download
+      env:
+        GO111MODULE: on
+    - id: package
+      name: Package release
+      run: ./release.sh debian
+      env:
+        GO111MODULE: on
+    - name: Upload binary package
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ steps.package.outputs.file }}
+        asset_name: ${{ steps.package.outputs.file }}
+        asset_content_type: application/vnd.debian.binary-package

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yb
 .DS_Store
 /yb_*_*_*.zip
 /yb-*-*-*.tgz
+*.deb

--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,7 @@ echo "CHANNEL=$CHANNEL" 1>&2
 echo "COMMIT=$COMMIT" 1>&2
 
 go build \
+  -buildmode=pie \
   -ldflags "-X 'main.version=$VERSION' -X 'main.date=$(date -u '+%FT%TZ')' -X 'main.channel=$CHANNEL' -X 'main.commitSHA=$COMMIT' -s -w" \
   -o "$1" \
   github.com/yourbase/yb 1>&2

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,13 @@
+Package: yb
+Version:
+Architecture: any
+Maintainer: YourBase <noreply@yourbase.io>
+Depends: libc6 (>= 2.4)
+Section: devel
+Priority: optional
+Homepage: https://yourbase.io/
+Description: Build tool optimized for local + remote development
+ YourBase is a build tool that makes working on projects much more
+ delightful. Stop worrying about dependencies, keep your CI build process
+ in-sync with your local development process and onboard new team members
+ with ease.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,23 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: yb
+Source: https://github.com/yourbase/yb
+
+Files: *
+Copyright: 2019-2020 YourBase Inc.
+License: Apache-2.0
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+ http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the complete text of the Apache version 2.0 license
+ can be found in "/usr/share/common-licenses/Apache-2.0".

--- a/debian/gg.lintian-overrides
+++ b/debian/gg.lintian-overrides
@@ -1,0 +1,2 @@
+yb: changelog-file-missing-in-native-package
+yb: binary-without-manpage usr/bin/yb

--- a/debpackage.sh
+++ b/debpackage.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Copyright 2020 YourBase Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# debpackage.sh builds a Debian binary package from the Go binary.
+# See https://tldp.org/HOWTO/html_single/Debian-Binary-Package-Building-HOWTO/
+
+set -euo pipefail
+
+if [[ $# -ne 0 ]]; then
+  echo "usage: VERSION=vX.Y.Z package.sh" 1>&2
+  exit 64
+fi
+
+# Identify directories and create temporary staging directory.
+outdir="$( pwd )"
+srcroot="$(dirname "${BASH_SOURCE[0]}")"
+stageroot="$(mktemp -d 2>/dev/null || mktemp -d -t yb_release)"
+cleanup() {
+  rm -rf "$stageroot"
+}
+trap cleanup EXIT
+
+# Compute version.
+VERSION="${VERSION:-DEVELOPMENT}"
+debversion="${VERSION/#v/}"
+debversion="${debversion//-/\~}"
+
+# Verify that OS/architecture is something we handle.
+if [[ "$( go env GOOS )" != linux ]]; then
+  echo "Not running on Linux; quitting." 1>&2
+  exit 1
+fi
+case "$( go env GOARCH )" in
+  amd64)
+    debarch="amd64"
+    ;;
+  *)
+    echo "TODO: Unknown architecture. GOARCH=$( go env GOARCH )" 1>&2
+    exit 1
+    ;;
+esac
+
+# Stage Debian tree.
+mkdir -m 755 \
+  "$stageroot/DEBIAN" \
+  "$stageroot/usr" \
+  "$stageroot/usr/bin" \
+  "$stageroot/usr/share" \
+  "$stageroot/usr/share/doc" \
+  "$stageroot/usr/share/doc/yb"
+install -m 644 "$srcroot/debian/control" "$stageroot/DEBIAN/control"
+sed -i -e "s/^Version:.*/Version: $debversion/" "$stageroot/DEBIAN/control"
+sed -i -e "s/^Architecture: any\$/Architecture: $debarch/" "$stageroot/DEBIAN/control"
+install -m 644 "$srcroot/debian/copyright" "$stageroot/usr/share/doc/yb/copyright"
+"$srcroot/build.sh" "$stageroot/usr/bin/yb"
+chmod 755 "$stageroot/usr/bin/yb"
+
+mkdir -m 755 \
+  "$stageroot/usr/share/lintian" \
+  "$stageroot/usr/share/lintian/overrides"
+install -m 644 \
+  "$srcroot/debian/gg.lintian-overrides" \
+  "$stageroot/usr/share/lintian/overrides/yb"
+
+# Create binary package.
+fakeroot dpkg-deb --build "$stageroot" "$outdir" 1>&2
+debfile="yb_${debversion}_${debarch}.deb"
+lintian "$debfile" 1>&2
+echo "$debfile"
+


### PR DESCRIPTION
Bypasses the Debian source packaging route, since we have a lot of Go dependencies and we don't want to package them all for Debian.

Fixes ch-2577