### PR TITLE
Fix Python buildpack Anaconda download URL

### DIFF
--- a/buildpacks/anaconda.go
+++ b/buildpacks/anaconda.go
@@ -17,8 +17,8 @@ type anacondaBuildTool struct {
 	pyCompatibleNum int
 }
 
-const anacondaDistMirrorTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
-const anacondaNewerDistMirrorTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.PyMajorVersion}}_{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
+const anacondaDistMirrorTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyMajor}}-{{.Version}}-{{.OS}}-{{.Arch}}.sh"
+const anacondaNewerDistMirrorTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyMajor}}-py{{.PyMajor}}{{.PyMinor}}_{{.Version}}-{{.OS}}-{{.Arch}}.sh"
 
 func newAnaconda2BuildTool(toolSpec buildToolSpec) anacondaBuildTool {
 	tool := anacondaBuildTool{
@@ -53,10 +53,16 @@ func (bt anacondaBuildTool) install(ctx context.Context) error {
 	} else {
 		log.Infof(ctx, "Installing anaconda")
 
-		downloadUrl := bt.downloadURL(ctx)
+		// Just so happens that for right now, Python 2.7 and 3.7
+		// are the ones used for Miniconda.
+		const pyMinor = 7
+		downloadURL, err := anacondaDownloadURL(bt.version, bt.pyCompatibleNum, pyMinor)
+		if err != nil {
+			return fmt.Errorf("anaconda buildpack: %w", err)
+		}
 
-		log.Infof(ctx, "Downloading Miniconda from URL %s...", downloadUrl)
-		localFile, err := plumbing.DownloadFileWithCache(downloadUrl)
+		log.Infof(ctx, "Downloading Miniconda from URL %s...", downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v\n", err)
 			return err
@@ -74,68 +80,60 @@ func (bt anacondaBuildTool) install(ctx context.Context) error {
 	return nil
 }
 
-func (bt anacondaBuildTool) downloadURL(ctx context.Context) string {
-	var v semver.Version
-
-	opsys := OS()
-	arch := Arch()
-	extension := "sh"
-	version := bt.version
-
-	if version == "" {
-		version = "latest"
-	} else {
-		var errv error
-		v, errv = semver.Parse(version)
-		if errv != nil {
-			return ""
-		}
+// TODO(light): Only being shared for testing. Once OS/Arch is able to be set in
+// test, we can have fixed constant strings as expected outputs.
+var (
+	anacondaOSMap = map[string]string{
+		"darwin": "MacOSX",
+		"linux":  "Linux",
+		// TODO(light): Omitting Windows, since the extension also needs to change to .exe.
 	}
-
-	if arch == "amd64" {
-		arch = "x86_64"
+	anacondaArchMap = map[string]string{
+		"amd64": "x86_64",
+		"386":   "x86",
 	}
+)
 
-	if opsys == "darwin" {
-		opsys = "MacOSX"
+func anacondaDownloadURL(version string, pyMajor, pyMinor int) (string, error) {
+	v, err := semver.Parse(version)
+	if err != nil {
+		return "", fmt.Errorf("compute anaconda %s download url: %w", version, err)
 	}
-
-	if opsys == "linux" {
-		opsys = "Linux"
+	opsys := anacondaOSMap[OS()]
+	if opsys == "" {
+		return "", fmt.Errorf("compute anaconda %s download url: not found for OS %s", version, OS())
 	}
-
-	if opsys == "windows" {
-		opsys = "Windows"
-		extension = "exe"
+	arch := anacondaArchMap[Arch()]
+	if arch == "" {
+		return "", fmt.Errorf("compute anaconda %s download url: not found for architecture %s", version, Arch())
 	}
 
 	data := struct {
-		PyNum          int
-		PyMajorVersion string
-		OS             string
-		Arch           string
-		Version        string
-		Extension      string
+		PyMajor int
+		PyMinor int
+		OS      string
+		Arch    string
+		Version string
 	}{
-		bt.pyCompatibleNum,
-		"py37",
+		pyMajor,
+		pyMinor,
 		opsys,
 		arch,
 		version,
-		extension,
 	}
 
-	// Newest Miniconda installs has different installers for Python 3.7 and Python 3.8
-	// We'll stick to Python 3.7, the stable version right now
-	if v.Major == 4 && v.Minor == 8 {
+	if v.Major > 4 || (v.Major == 4 && v.Minor >= 8) {
 		url, err := plumbing.TemplateToString(anacondaNewerDistMirrorTemplate, data)
-		log.Errorf(ctx, "Unable to apply template: %v", err)
-		return url
+		if err != nil {
+			return "", fmt.Errorf("compute anaconda %s download url: %w", version, err)
+		}
+		return url, nil
 	}
 	url, err := plumbing.TemplateToString(anacondaDistMirrorTemplate, data)
-	log.Errorf(ctx, "Unable to apply template: %v", err)
-
-	return url
+	if err != nil {
+		return "", fmt.Errorf("compute anaconda %s download url: %w", version, err)
+	}
+	return url, nil
 }
 
 func (bt anacondaBuildTool) setup(ctx context.Context) error {
@@ -144,7 +142,8 @@ func (bt anacondaBuildTool) setup(ctx context.Context) error {
 	setupDir := bt.spec.packageDir
 
 	for _, cmd := range []string{
-		"conda config --set always_yes yes --set changeps1 no",
+		"conda config --set always_yes yes",
+		"conda config --set changeps1 no",
 		"conda update -q conda",
 	} {
 		log.Infof(ctx, "Running: '%v' ", cmd)

--- a/buildpacks/anaconda_test.go
+++ b/buildpacks/anaconda_test.go
@@ -1,0 +1,110 @@
+// Copyright 2020 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package buildpacks
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/yourbase/commons/http/headers"
+)
+
+func TestAnacondaDownloadURL(t *testing.T) {
+	osArchGolden := anacondaOSMap[OS()] + "-" + anacondaArchMap[Arch()]
+	tests := []struct {
+		version   string
+		pyMajor   int
+		pyMinor   int
+		want      string
+		wantError bool
+	}{
+		{
+			version: "4.8.3",
+			pyMajor: 3,
+			pyMinor: 7,
+			want:    "https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.3-" + osArchGolden + ".sh",
+		},
+		{
+			version: "4.8.3",
+			pyMajor: 3,
+			pyMinor: 8,
+			want:    "https://repo.continuum.io/miniconda/Miniconda3-py38_4.8.3-" + osArchGolden + ".sh",
+		},
+		{
+			version: "4.8.3",
+			pyMajor: 2,
+			pyMinor: 7,
+			want:    "https://repo.continuum.io/miniconda/Miniconda2-py27_4.8.3-" + osArchGolden + ".sh",
+		},
+		{
+			version: "4.7.10",
+			pyMajor: 3,
+			pyMinor: 7,
+			want:    "https://repo.continuum.io/miniconda/Miniconda3-4.7.10-" + osArchGolden + ".sh",
+		},
+		{
+			version: "4.7.10",
+			pyMajor: 3,
+			pyMinor: 8,
+			want:    "https://repo.continuum.io/miniconda/Miniconda3-4.7.10-" + osArchGolden + ".sh",
+		},
+		{
+			version: "4.7.10",
+			pyMajor: 2,
+			pyMinor: 7,
+			want:    "https://repo.continuum.io/miniconda/Miniconda2-4.7.10-" + osArchGolden + ".sh",
+		},
+	}
+	for _, test := range tests {
+		got, err := anacondaDownloadURL(test.version, test.pyMajor, test.pyMinor)
+		if got != test.want || (err != nil) != test.wantError {
+			errString := "<nil>"
+			if test.wantError {
+				errString = "<error>"
+			}
+			t.Errorf("anacondaDownloadURL(%q, %d, %d) = %q, %v; want %q, %s", test.version, test.pyMajor, test.pyMinor, got, err, test.want, errString)
+		}
+	}
+
+	t.Run("Existence", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("Skipping due to -short")
+		}
+		for _, test := range tests {
+			if test.wantError {
+				continue
+			}
+			resp, err := http.Head(test.want)
+			if err != nil {
+				t.Errorf("FAIL %s: %v", test.want, err)
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("FAIL %s: HTTP %s", test.want, resp.Status)
+				continue
+			}
+			t.Logf("%s found. %s: %s %s: %s",
+				test.want,
+				headers.ContentType,
+				resp.Header.Get(headers.ContentType),
+				headers.ContentLength,
+				resp.Header.Get(headers.ContentLength),
+			)
+		}
+	})
+}

--- a/buildpacks/python.go
+++ b/buildpacks/python.go
@@ -10,11 +10,7 @@ import (
 	"zombiezen.com/go/log"
 )
 
-const (
-	anacondaToolVersion = "4.8.3"
-	// The version above needs a newer template
-	anacondaURLTemplate = "https://repo.continuum.io/miniconda/Miniconda{{.PyNum}}-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Extension}}"
-)
+const pythonAnacondaToolVersion = "4.8.3"
 
 type pythonBuildTool struct {
 	version string
@@ -31,7 +27,7 @@ func newPythonBuildTool(toolSpec buildToolSpec) pythonBuildTool {
 }
 
 func (bt pythonBuildTool) anacondaInstallDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "miniconda3", fmt.Sprintf("miniconda-%s", anacondaToolVersion))
+	return filepath.Join(bt.spec.sharedCacheDir, "miniconda3", "miniconda-"+pythonAnacondaToolVersion)
 }
 
 func (bt pythonBuildTool) environmentDir() string {
@@ -47,10 +43,13 @@ func (bt pythonBuildTool) install(ctx context.Context) error {
 	} else {
 		log.Infof(ctx, "Installing anaconda")
 
-		downloadUrl := bt.downloadURL()
+		downloadURL, err := anacondaDownloadURL(pythonAnacondaToolVersion, 3, 7)
+		if err != nil {
+			return fmt.Errorf("python buildpack: %w", err)
+		}
 
-		log.Infof(ctx, "Downloading Miniconda from URL %s...", downloadUrl)
-		localFile, err := plumbing.DownloadFileWithCache(downloadUrl)
+		log.Infof(ctx, "Downloading Miniconda from URL %s...", downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err
@@ -70,52 +69,6 @@ func (bt pythonBuildTool) install(ctx context.Context) error {
 	return nil
 }
 
-func (bt pythonBuildTool) downloadURL() string {
-	opsys := OS()
-	arch := Arch()
-	extension := "sh"
-	version := bt.version
-
-	if version == "" {
-		version = "latest"
-	}
-
-	if arch == "amd64" {
-		arch = "x86_64"
-	}
-
-	if opsys == "darwin" {
-		opsys = "MacOSX"
-	}
-
-	if opsys == "linux" {
-		opsys = "Linux"
-	}
-
-	if opsys == "windows" {
-		opsys = "Windows"
-		extension = "exe"
-	}
-
-	data := struct {
-		PyNum     int
-		OS        string
-		Arch      string
-		Version   string
-		Extension string
-	}{
-		3,
-		opsys,
-		arch,
-		anacondaToolVersion,
-		extension,
-	}
-
-	url, _ := plumbing.TemplateToString(anacondaURLTemplate, data)
-
-	return url
-}
-
 func (bt pythonBuildTool) setup(ctx context.Context) error {
 	condaDir := bt.anacondaInstallDir()
 	envDir := bt.environmentDir()
@@ -129,8 +82,9 @@ func (bt pythonBuildTool) setup(ctx context.Context) error {
 		condaBin := filepath.Join(condaDir, "bin", "conda")
 
 		for _, cmd := range []string{
+			fmt.Sprintf("%s config --set always_yes yes", condaBin),
+			fmt.Sprintf("%s config --set changeps1 no", condaBin),
 			fmt.Sprintf("%s install -c anaconda setuptools", condaBin),
-			fmt.Sprintf("%s config --set always_yes yes --set changeps1 no", condaBin),
 			fmt.Sprintf("%s update -q conda", condaBin),
 			fmt.Sprintf("%s create --prefix %s python=%s", condaBin, envDir, bt.version),
 		} {


### PR DESCRIPTION
Use same logic as in Anaconda buildpack and add unit tests to verify. Tweaked Python buildpack to properly disable interactive prompt.

Fixes ch-2671