### PR TITLE
Remove ToolsDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 ## [Unreleased][]
 
+### Changed
+
+-  Buildpacks are no longer installed to `$HOME/.yourbase/tools`. They are now
+   installed into the per-build context cache. You can safely remove
+   `$HOME/.yourbase/tools` to reclaim disk space.
+
 ### Fixed
 
 -  Update to latest version of [Narwhal](https://github.com/yourbase/narwhal),

--- a/buildpacks/anaconda.go
+++ b/buildpacks/anaconda.go
@@ -42,7 +42,7 @@ func newAnaconda3BuildTool(toolSpec buildToolSpec) anacondaBuildTool {
 }
 
 func (bt anacondaBuildTool) installDir() string {
-	return filepath.Join(bt.spec.packageCacheDir, "miniconda", fmt.Sprintf("miniconda-%s", bt.version))
+	return filepath.Join(bt.spec.cacheDir, "miniconda", fmt.Sprintf("miniconda-%s", bt.version))
 }
 
 func (bt anacondaBuildTool) install(ctx context.Context) error {

--- a/buildpacks/android_ndk.go
+++ b/buildpacks/android_ndk.go
@@ -59,7 +59,7 @@ func (bt androidNDKBuildTool) downloadURL() string {
 }
 
 func (bt androidNDKBuildTool) installDir() string {
-	return filepath.Join(plumbing.ToolsDir(), "android-ndk")
+	return filepath.Join(bt.spec.cacheDir, "android-ndk")
 }
 
 func (bt androidNDKBuildTool) ndkDir() string {

--- a/buildpacks/android_sdk.go
+++ b/buildpacks/android_sdk.go
@@ -73,7 +73,7 @@ func (bt androidBuildTool) majorVersion() string {
 }
 
 func (bt androidBuildTool) installDir() string {
-	return filepath.Join(plumbing.ToolsDir(), "android", fmt.Sprintf("android-%s", bt.version))
+	return filepath.Join(bt.spec.cacheDir, "android", fmt.Sprintf("android-%s", bt.version))
 }
 
 func (bt androidBuildTool) androidDir() string {

--- a/buildpacks/ant.go
+++ b/buildpacks/ant.go
@@ -57,7 +57,7 @@ func (bt antBuildTool) antDir() string {
 }
 
 func (bt antBuildTool) installDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "ant")
+	return filepath.Join(bt.spec.cacheDir, "ant")
 }
 
 func (bt antBuildTool) setup(ctx context.Context) error {

--- a/buildpacks/buildpack_loader.go
+++ b/buildpacks/buildpack_loader.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/yourbase/yb/internal/ybtrace"
-	"github.com/yourbase/yb/plumbing"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/label"
@@ -14,11 +13,10 @@ import (
 )
 
 type buildToolSpec struct {
-	tool            string
-	version         string
-	sharedCacheDir  string
-	packageCacheDir string
-	packageDir      string
+	tool       string
+	version    string
+	cacheDir   string
+	packageDir string
 }
 
 // Install installs the buildpack given by spec.
@@ -28,14 +26,11 @@ func Install(ctx context.Context, pkgCacheDir string, pkgDir string, spec string
 		return fmt.Errorf("load build packs: %w", err)
 	}
 
-	sharedCacheDir := plumbing.ToolsDir()
-
 	parsed := buildToolSpec{
-		tool:            buildpackName,
-		version:         versionString,
-		sharedCacheDir:  sharedCacheDir,
-		packageCacheDir: pkgCacheDir,
-		packageDir:      pkgDir,
+		tool:       buildpackName,
+		version:    versionString,
+		cacheDir:   pkgCacheDir,
+		packageDir: pkgDir,
 	}
 
 	var bt interface {

--- a/buildpacks/dart.go
+++ b/buildpacks/dart.go
@@ -67,7 +67,7 @@ func (bt dartBuildTool) majorVersion() string {
 }
 
 func (bt dartBuildTool) installDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "dart", bt.version)
+	return filepath.Join(bt.spec.cacheDir, "dart", bt.version)
 }
 
 func (bt dartBuildTool) dartDir() string {

--- a/buildpacks/flutter.go
+++ b/buildpacks/flutter.go
@@ -86,7 +86,7 @@ func (bt flutterBuildTool) majorVersion() string {
 }
 
 func (bt flutterBuildTool) installDir() string {
-	return filepath.Join(bt.spec.packageCacheDir, "flutter", fmt.Sprintf("flutter-%s", bt.version))
+	return filepath.Join(bt.spec.cacheDir, "flutter", fmt.Sprintf("flutter-%s", bt.version))
 }
 
 func (bt flutterBuildTool) flutterDir() string {

--- a/buildpacks/glide.go
+++ b/buildpacks/glide.go
@@ -35,7 +35,7 @@ func newGlideBuildTool(toolSpec buildToolSpec) glideBuildTool {
 }
 
 func (bt glideBuildTool) glideDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, fmt.Sprintf("glide-%v", bt.version))
+	return filepath.Join(bt.spec.cacheDir, fmt.Sprintf("glide-%v", bt.version))
 }
 
 func (bt glideBuildTool) setup(ctx context.Context) error {

--- a/buildpacks/golang.go
+++ b/buildpacks/golang.go
@@ -50,7 +50,7 @@ func (bt golangBuildTool) majorVersion() string {
 }
 
 func (bt golangBuildTool) installDir() string {
-	return fmt.Sprintf("%s/go/%s", bt.spec.sharedCacheDir, bt.version)
+	return fmt.Sprintf("%s/go/%s", bt.spec.cacheDir, bt.version)
 }
 
 func (bt golangBuildTool) golangDir() string {
@@ -60,7 +60,7 @@ func (bt golangBuildTool) golangDir() string {
 // TODO: handle multiple packages, for now this is ok
 func (bt golangBuildTool) setup(ctx context.Context) error {
 	golangDir := bt.golangDir()
-	goPath := bt.spec.packageCacheDir
+	goPath := bt.spec.cacheDir
 	pkgPath := bt.spec.packageDir
 
 	var goPathElements = []string{goPath, pkgPath}

--- a/buildpacks/gradle.go
+++ b/buildpacks/gradle.go
@@ -62,12 +62,12 @@ func (bt gradleBuildTool) gradleDir() string {
 }
 
 func (bt gradleBuildTool) installDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "gradle")
+	return filepath.Join(bt.spec.cacheDir, "gradle")
 }
 
 func (bt gradleBuildTool) setup(ctx context.Context) error {
 	gradleDir := bt.gradleDir()
-	gradleHome := filepath.Join(bt.spec.packageCacheDir, "gradle-home", bt.version)
+	gradleHome := filepath.Join(bt.spec.cacheDir, "gradle-home", bt.version)
 
 	cmdPath := filepath.Join(gradleDir, "bin")
 	currentPath := os.Getenv("PATH")

--- a/buildpacks/heroku.go
+++ b/buildpacks/heroku.go
@@ -60,7 +60,7 @@ func (bt herokuBuildTool) majorVersion() string {
 }
 
 func (bt herokuBuildTool) herokuDir() string {
-	return fmt.Sprintf("%s/heroku-%s", bt.spec.packageCacheDir, bt.version)
+	return fmt.Sprintf("%s/heroku-%s", bt.spec.cacheDir, bt.version)
 }
 
 func (bt herokuBuildTool) setup(ctx context.Context) error {

--- a/buildpacks/homebrew.go
+++ b/buildpacks/homebrew.go
@@ -96,7 +96,7 @@ func (bt homebrewBuildTool) homebrewDir() string {
 }
 
 func (bt homebrewBuildTool) installDir() string {
-	return filepath.Join(bt.spec.packageCacheDir, "homebrew")
+	return filepath.Join(bt.spec.cacheDir, "homebrew")
 }
 
 func (bt homebrewBuildTool) install(ctx context.Context) error {

--- a/buildpacks/maven.go
+++ b/buildpacks/maven.go
@@ -50,7 +50,7 @@ func (bt mavenBuildTool) majorVersion() string {
 }
 
 func (bt mavenBuildTool) installDir() string {
-	return filepath.Join(plumbing.ToolsDir(), "maven")
+	return filepath.Join(bt.spec.cacheDir, "maven")
 }
 
 func (bt mavenBuildTool) mavenDir() string {

--- a/buildpacks/nodejs.go
+++ b/buildpacks/nodejs.go
@@ -46,7 +46,7 @@ func (bt nodeBuildTool) nodeDir() string {
 }
 
 func (bt nodeBuildTool) installDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "nodejs")
+	return filepath.Join(bt.spec.cacheDir, "nodejs")
 }
 
 func (bt nodeBuildTool) install(ctx context.Context) error {

--- a/buildpacks/openjdk.go
+++ b/buildpacks/openjdk.go
@@ -94,7 +94,7 @@ func newJavaBuildTool(ctx context.Context, toolSpec buildToolSpec) javaBuildTool
 }
 
 func (bt javaBuildTool) installDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "java")
+	return filepath.Join(bt.spec.cacheDir, "java")
 }
 
 func (bt javaBuildTool) javaDir() string {

--- a/buildpacks/openjdk_test.go
+++ b/buildpacks/openjdk_test.go
@@ -93,11 +93,10 @@ func TestOpenJDKUrlGeneration(t *testing.T) {
 		},
 	} {
 		bt := newJavaBuildTool(ctx, buildToolSpec{
-			tool:            "java",
-			version:         data.version,
-			sharedCacheDir:  "/tmp/ybcache",
-			packageCacheDir: "/tmp/pkgcache",
-			packageDir:      "/opt/tools/java",
+			tool:       "java",
+			version:    data.version,
+			cacheDir:   "/tmp/pkgcache",
+			packageDir: "/opt/tools/java",
 		})
 
 		url := bt.downloadURL(ctx)

--- a/buildpacks/protoc.go
+++ b/buildpacks/protoc.go
@@ -69,7 +69,7 @@ func (bt protocBuildTool) majorVersion() string {
 }
 
 func (bt protocBuildTool) installDir() string {
-	return filepath.Join(bt.spec.packageCacheDir, "protoc", fmt.Sprintf("protoc-%s", bt.version))
+	return filepath.Join(bt.spec.cacheDir, "protoc", fmt.Sprintf("protoc-%s", bt.version))
 }
 
 func (bt protocBuildTool) protocDir() string {

--- a/buildpacks/python.go
+++ b/buildpacks/python.go
@@ -28,11 +28,11 @@ func newPythonBuildTool(toolSpec buildToolSpec) pythonBuildTool {
 }
 
 func (bt pythonBuildTool) anacondaInstallDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "miniconda3", "miniconda-"+pythonAnacondaToolVersion)
+	return filepath.Join(bt.spec.cacheDir, "miniconda3", "miniconda-"+pythonAnacondaToolVersion)
 }
 
 func (bt pythonBuildTool) environmentDir() string {
-	return filepath.Join(bt.spec.packageCacheDir, "conda-python", bt.version)
+	return filepath.Join(bt.spec.cacheDir, "conda-python", bt.version)
 }
 
 func (bt pythonBuildTool) install(ctx context.Context) error {

--- a/buildpacks/rlang.go
+++ b/buildpacks/rlang.go
@@ -48,7 +48,7 @@ func (bt rLangBuildTool) majorVersion() string {
 }
 
 func (bt rLangBuildTool) installDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "R")
+	return filepath.Join(bt.spec.cacheDir, "R")
 }
 
 func (bt rLangBuildTool) rLangDir() string {

--- a/buildpacks/ruby.go
+++ b/buildpacks/ruby.go
@@ -87,7 +87,7 @@ func (bt rubyBuildTool) rubyDir() string {
 }
 
 func (bt rubyBuildTool) rbenvDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "rbenv")
+	return filepath.Join(bt.spec.cacheDir, "rbenv")
 }
 
 func (bt rubyBuildTool) binaryExists(ctx context.Context) bool {
@@ -193,7 +193,7 @@ func (bt rubyBuildTool) install(ctx context.Context) error {
 }
 
 func (bt rubyBuildTool) setup(ctx context.Context) error {
-	gemsDir := filepath.Join(bt.spec.packageCacheDir, "rubygems")
+	gemsDir := filepath.Join(bt.spec.cacheDir, "rubygems")
 	if err := os.MkdirAll(gemsDir, 0777); err != nil {
 		return fmt.Errorf("install Ruby: %w", err)
 	}

--- a/buildpacks/rust.go
+++ b/buildpacks/rust.go
@@ -32,7 +32,7 @@ func (bt rustBuildTool) rustDir() string {
 }
 
 func (bt rustBuildTool) installDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "rust")
+	return filepath.Join(bt.spec.cacheDir, "rust")
 }
 
 func (bt rustBuildTool) setup(ctx context.Context) error {
@@ -68,7 +68,7 @@ func (bt rustBuildTool) install(ctx context.Context) error {
 		installerFile := fmt.Sprintf("rustup-init%s", extension)
 		downloadURL := fmt.Sprintf("%s/%s-%s/%s", rustDistMirror, arch, operatingSystem, installerFile)
 
-		downloadDir := bt.spec.packageCacheDir
+		downloadDir := bt.spec.cacheDir
 		localFile := filepath.Join(downloadDir, installerFile)
 		log.Infof(ctx, "Downloading from URL %s to local file %s", downloadURL, localFile)
 		err := plumbing.DownloadFile(ctx, http.DefaultClient, localFile, downloadURL)

--- a/buildpacks/yarn.go
+++ b/buildpacks/yarn.go
@@ -31,7 +31,7 @@ func (bt yarnBuildTool) yarnDir() string {
 }
 
 func (bt yarnBuildTool) installDir() string {
-	return filepath.Join(bt.spec.sharedCacheDir, "yarn")
+	return filepath.Join(bt.spec.cacheDir, "yarn")
 }
 
 func (bt yarnBuildTool) downloadURL() string {

--- a/plumbing/util.go
+++ b/plumbing/util.go
@@ -198,24 +198,6 @@ func RemoveWritePermissionRecursively(path string) bool {
 	return true
 }
 
-func ToolsDir() string {
-	toolsDir, exists := os.LookupEnv("YB_TOOLS_DIR")
-	if !exists {
-		u, err := user.Current()
-		if err != nil {
-			toolsDir = "/tmp/yourbase/tools"
-		} else {
-			toolsDir = fmt.Sprintf("%s/.yourbase/tools", u.HomeDir)
-		}
-	}
-
-	if err := os.MkdirAll(toolsDir, 0777); err != nil {
-		log.Errorf(context.TODO(), "%v", err)
-	}
-
-	return toolsDir
-}
-
 func CacheDir() string {
 	cacheDir, exists := os.LookupEnv("YB_CACHE_DIR")
 	if !exists {


### PR DESCRIPTION
The buildpacks are now per-target and will likely need to be more fine-grained over time. Storing the data along with the target that uses it increases reproducibility and simplifies cleanup at the cost of download time and disk space. The former can be addressed with judicious use of `DownloadFileWithCache`.

Updates ch-1401
Updates ch-2567