### PR TITLE
Pass in data directories as an explicit input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 ### Changed
 
--  Buildpacks are no longer installed to `$HOME/.yourbase/tools`. They are now
-   installed into the per-build context cache. You can safely remove
-   `$HOME/.yourbase/tools` to reclaim disk space.
+-  The build cache is now created under `$XDG_CACHE_HOME/yb`
+   (usually `$HOME/.cache/yb`) rather than `$HOME/.yourbase`.
+   You can safely remove `$HOME/.yourbase` to reclaim disk space.
 
 ### Fixed
 

--- a/buildpacks/anaconda.go
+++ b/buildpacks/anaconda.go
@@ -63,7 +63,7 @@ func (bt anacondaBuildTool) install(ctx context.Context) error {
 		}
 
 		log.Infof(ctx, "Downloading Miniconda from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v\n", err)
 			return err

--- a/buildpacks/android_ndk.go
+++ b/buildpacks/android_ndk.go
@@ -87,7 +87,7 @@ func (bt androidNDKBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Android NDK v%s from URL %s...", bt.version, downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/android_sdk.go
+++ b/buildpacks/android_sdk.go
@@ -142,7 +142,7 @@ func (bt androidBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Android from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/ant.go
+++ b/buildpacks/ant.go
@@ -84,7 +84,7 @@ func (bt antBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Ant from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/buildpack_loader.go
+++ b/buildpacks/buildpack_loader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/internal/ybtrace"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/codes"
@@ -15,12 +16,13 @@ import (
 type buildToolSpec struct {
 	tool       string
 	version    string
+	dataDirs   *ybdata.Dirs
 	cacheDir   string
 	packageDir string
 }
 
 // Install installs the buildpack given by spec.
-func Install(ctx context.Context, pkgCacheDir string, pkgDir string, spec string) error {
+func Install(ctx context.Context, dataDirs *ybdata.Dirs, pkgCacheDir string, pkgDir string, spec string) error {
 	buildpackName, versionString, err := SplitToolSpec(spec)
 	if err != nil {
 		return fmt.Errorf("load build packs: %w", err)
@@ -29,6 +31,7 @@ func Install(ctx context.Context, pkgCacheDir string, pkgDir string, spec string
 	parsed := buildToolSpec{
 		tool:       buildpackName,
 		version:    versionString,
+		dataDirs:   dataDirs,
 		cacheDir:   pkgCacheDir,
 		packageDir: pkgDir,
 	}

--- a/buildpacks/dart.go
+++ b/buildpacks/dart.go
@@ -94,7 +94,7 @@ func (bt dartBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Dart from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/flutter.go
+++ b/buildpacks/flutter.go
@@ -117,7 +117,7 @@ func (bt flutterBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Flutter from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/glide.go
+++ b/buildpacks/glide.go
@@ -70,7 +70,7 @@ func (bt glideBuildTool) install(ctx context.Context) error {
 		}
 
 		log.Infof(ctx, "Downloading from URL %s ...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/golang.go
+++ b/buildpacks/golang.go
@@ -93,7 +93,7 @@ func (bt golangBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading from URL %s ...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/gradle.go
+++ b/buildpacks/gradle.go
@@ -93,7 +93,7 @@ func (bt gradleBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Gradle from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/heroku.go
+++ b/buildpacks/heroku.go
@@ -85,7 +85,7 @@ func (bt herokuBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Heroku from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/maven.go
+++ b/buildpacks/maven.go
@@ -79,7 +79,7 @@ func (bt mavenBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Maven from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/nodejs.go
+++ b/buildpacks/nodejs.go
@@ -62,7 +62,7 @@ func (bt nodeBuildTool) install(ctx context.Context) error {
 		archiveFile := fmt.Sprintf("%s.tar.gz", nodePkgString)
 		downloadURL := fmt.Sprintf("%s/v%s/%s", nodeDistMirror, bt.version, archiveFile)
 		log.Infof(ctx, "Downloading from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/openjdk.go
+++ b/buildpacks/openjdk.go
@@ -218,7 +218,7 @@ func (bt javaBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL(ctx)
 
 		log.Infof(ctx, "Downloading from URL %s ", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/protoc.go
+++ b/buildpacks/protoc.go
@@ -97,7 +97,7 @@ func (bt protocBuildTool) install(ctx context.Context) error {
 	downloadURL := bt.downloadURL()
 
 	log.Infof(ctx, "Downloading Protoc from URL %s...", downloadURL)
-	localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+	localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 	if err != nil {
 		log.Errorf(ctx, "Unable to download: %v", err)
 		return err

--- a/buildpacks/python.go
+++ b/buildpacks/python.go
@@ -50,7 +50,7 @@ func (bt pythonBuildTool) install(ctx context.Context) error {
 		}
 
 		log.Infof(ctx, "Downloading Miniconda from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/rlang.go
+++ b/buildpacks/rlang.go
@@ -79,7 +79,7 @@ func (bt rLangBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading from URL %s ...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/buildpacks/ruby.go
+++ b/buildpacks/ruby.go
@@ -121,7 +121,7 @@ func (bt rubyBuildTool) install(ctx context.Context) error {
 			downloadURL := bt.downloadURL(ctx)
 			log.Infof(ctx, "Will download pre-built Ruby from %s", downloadURL)
 
-			localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+			localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 			if err != nil {
 				log.Errorf(ctx, "Unable to download: %v", err)
 				return err

--- a/buildpacks/yarn.go
+++ b/buildpacks/yarn.go
@@ -58,7 +58,7 @@ func (bt yarnBuildTool) install(ctx context.Context) error {
 		log.Infof(ctx, "Will install Yarn v%s into %s", bt.version, installDir)
 		downloadURL := bt.downloadURL()
 		log.Infof(ctx, "Downloading from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, downloadURL)
+		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			return fmt.Errorf("Unable to download %s: %v", downloadURL, err)
 		}

--- a/cli/build.go
+++ b/cli/build.go
@@ -94,7 +94,7 @@ func (b *BuildCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{
 	}
 	global.SetTraceProvider(tp)
 
-	dataDirs, err := ybdata.FromEnv()
+	dataDirs, err := ybdata.DirsFromEnv()
 	if err != nil {
 		log.Errorf(ctx, "%v", err)
 		return subcommands.ExitFailure

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -10,6 +10,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/johnewart/subcommands"
 	"github.com/yourbase/narwhal"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -39,6 +40,11 @@ Executing the target involves:
 3. Start target
 */
 func (b *ExecCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	dataDirs, err := ybdata.FromEnv()
+	if err != nil {
+		log.Errorf(ctx, "%v", err)
+		return subcommands.ExitFailure
+	}
 
 	targetPackage, err := GetTargetPackage()
 	if err != nil {
@@ -46,7 +52,7 @@ func (b *ExecCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}
 		return subcommands.ExitFailure
 	}
 
-	if err := targetPackage.SetupRuntimeDependencies(ctx); err != nil {
+	if err := targetPackage.SetupRuntimeDependencies(ctx, dataDirs); err != nil {
 		log.Infof(ctx, "Couldn't configure dependencies: %v\n", err)
 		return subcommands.ExitFailure
 	}
@@ -63,7 +69,12 @@ func (b *ExecCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}
 			return subcommands.ExitFailure
 		}
 
-		localContainerWorkDir := filepath.Join(targetPackage.BuildRoot(), "containers")
+		buildRoot, err := targetPackage.BuildRoot(dataDirs)
+		if err != nil {
+			log.Errorf(ctx, "%v", err)
+			return subcommands.ExitFailure
+		}
+		localContainerWorkDir := filepath.Join(buildRoot, "containers")
 		if err := os.MkdirAll(localContainerWorkDir, 0777); err != nil {
 			log.Errorf(ctx, "Couldn't create directory: %v", err)
 			return subcommands.ExitFailure
@@ -71,7 +82,7 @@ func (b *ExecCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}
 
 		log.Infof(ctx, "Will use %s as the dependency work dir", localContainerWorkDir)
 		log.Infof(ctx, "Starting %d dependencies...", len(containers))
-		sc, err := narwhal.NewServiceContextWithId(ctx, dockerClient, "exec", targetPackage.BuildRoot())
+		sc, err := narwhal.NewServiceContextWithId(ctx, dockerClient, "exec", buildRoot)
 		if err != nil {
 			log.Errorf(ctx, "Couldn't create service context for dependencies: %v", err)
 			return subcommands.ExitFailure

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -40,7 +40,7 @@ Executing the target involves:
 3. Start target
 */
 func (b *ExecCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	dataDirs, err := ybdata.FromEnv()
+	dataDirs, err := ybdata.DirsFromEnv()
 	if err != nil {
 		log.Errorf(ctx, "%v", err)
 		return subcommands.ExitFailure

--- a/cli/run.go
+++ b/cli/run.go
@@ -40,7 +40,7 @@ func (b *RunCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{})
 		fmt.Println(b.Usage())
 		return subcommands.ExitFailure
 	}
-	dataDirs, err := ybdata.FromEnv()
+	dataDirs, err := ybdata.DirsFromEnv()
 	if err != nil {
 		log.Errorf(ctx, "%v", err)
 		return subcommands.ExitFailure

--- a/cli/run.go
+++ b/cli/run.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/subcommands"
+	"github.com/yourbase/yb/internal/ybdata"
 	"zombiezen.com/go/log"
 )
 
@@ -39,6 +40,11 @@ func (b *RunCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{})
 		fmt.Println(b.Usage())
 		return subcommands.ExitFailure
 	}
+	dataDirs, err := ybdata.FromEnv()
+	if err != nil {
+		log.Errorf(ctx, "%v", err)
+		return subcommands.ExitFailure
+	}
 
 	targetPackage, err := GetTargetPackage()
 	if err != nil {
@@ -49,7 +55,10 @@ func (b *RunCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{})
 	instructions := targetPackage.Manifest
 
 	log.Infof(ctx, "Setting up dependencies...")
-	targetPackage.SetupRuntimeDependencies(ctx)
+	if err := targetPackage.SetupRuntimeDependencies(ctx, dataDirs); err != nil {
+		log.Errorf(ctx, "%v", err)
+		return subcommands.ExitFailure
+	}
 
 	log.Infof(ctx, "Setting environment variables...")
 	for _, property := range instructions.Exec.Environment["default"] {

--- a/cli/workspace.go
+++ b/cli/workspace.go
@@ -68,7 +68,7 @@ func (w *workspaceLocationCmd) Execute(ctx context.Context, f *flag.FlagSet, _ .
 			return subcommands.ExitFailure
 		}
 
-		dataDirs, err := ybdata.FromEnv()
+		dataDirs, err := ybdata.DirsFromEnv()
 		if err != nil {
 			log.Errorf(ctx, "%v", err)
 			return subcommands.ExitFailure

--- a/cli/workspace.go
+++ b/cli/workspace.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/subcommands"
+	"github.com/yourbase/yb/internal/ybdata"
 	pkg "github.com/yourbase/yb/packages"
 	"github.com/yourbase/yb/plumbing"
 	ybtypes "github.com/yourbase/yb/types"
@@ -67,7 +68,17 @@ func (w *workspaceLocationCmd) Execute(ctx context.Context, f *flag.FlagSet, _ .
 			return subcommands.ExitFailure
 		}
 
-		log.Infof(ctx, "%s", pkg.BuildRoot())
+		dataDirs, err := ybdata.FromEnv()
+		if err != nil {
+			log.Errorf(ctx, "%v", err)
+			return subcommands.ExitFailure
+		}
+		buildRoot, err := pkg.BuildRoot(dataDirs)
+		if err != nil {
+			log.Errorf(ctx, "%v", err)
+			return subcommands.ExitFailure
+		}
+		log.Infof(ctx, "%s", buildRoot)
 		return subcommands.ExitSuccess
 	} else {
 		ws, err := workspace.LoadWorkspace()

--- a/internal/ybdata/ybdata.go
+++ b/internal/ybdata/ybdata.go
@@ -58,7 +58,7 @@ func DirsFromEnv() (*Dirs, error) {
 func NewDirs(root string) *Dirs {
 	return &Dirs{
 		cache:      root,
-		workspaces: filepath.Join(cache, "workspaces"),
+		workspaces: filepath.Join(root, "workspaces"),
 	}
 }
 

--- a/internal/ybdata/ybdata.go
+++ b/internal/ybdata/ybdata.go
@@ -32,8 +32,8 @@ type Dirs struct {
 	workspaces string
 }
 
-// FromEnv finds data directories based on environment variables.
-func FromEnv() (*Dirs, error) {
+// DirsFromEnv finds data directories based on environment variables.
+func DirsFromEnv() (*Dirs, error) {
 	cache := os.Getenv("YB_CACHE_DIR")
 	if cache == "" {
 		// TODO(light): This should use LocalAppData on Windows.
@@ -56,7 +56,10 @@ func FromEnv() (*Dirs, error) {
 // NewDirs returns a set of directories that is enclosed within a root directory.
 // This is useful for isolating test data.
 func NewDirs(root string) *Dirs {
-	return &Dirs{cache: root}
+	return &Dirs{
+		cache:      root,
+		workspaces: filepath.Join(cache, "workspaces"),
+	}
 }
 
 // Downloads returns the top-level directory to store downloaded files.

--- a/internal/ybdata/ybdata.go
+++ b/internal/ybdata/ybdata.go
@@ -1,0 +1,75 @@
+// Copyright 2020 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ybdata locates directories the user has designated or conventionally
+// uses for storing different types of data.
+package ybdata
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go4.org/xdgdir"
+)
+
+// Dirs is the result of locating directories.
+type Dirs struct {
+	cache      string
+	workspaces string
+}
+
+// FromEnv finds data directories based on environment variables.
+func FromEnv() (*Dirs, error) {
+	cache := os.Getenv("YB_CACHE_DIR")
+	if cache == "" {
+		// TODO(light): This should use LocalAppData on Windows.
+		rootCache := xdgdir.Cache.Path()
+		if rootCache == "" {
+			return nil, fmt.Errorf("neither YB_CACHE_DIR nor %v set", xdgdir.Cache)
+		}
+		cache = filepath.Join(rootCache, "yb")
+	}
+	workspaces := os.Getenv("YB_WORKSPACES_ROOT")
+	if workspaces == "" {
+		workspaces = filepath.Join(cache, "workspaces")
+	}
+	return &Dirs{
+		cache:      cache,
+		workspaces: workspaces,
+	}, nil
+}
+
+// NewDirs returns a set of directories that is enclosed within a root directory.
+// This is useful for isolating test data.
+func NewDirs(root string) *Dirs {
+	return &Dirs{cache: root}
+}
+
+// Downloads returns the top-level directory to store downloaded files.
+// This directory may not exist yet.
+func (dirs *Dirs) Downloads() string {
+	return filepath.Join(dirs.cache, "downloads")
+}
+
+// Workspaces returns the top-level directory to store cached data for each
+// package. This directory may not exist yet.
+//
+// TODO(light): This should get moved to a directory physically in the package
+// directory.
+func (dirs *Dirs) Workspaces() string {
+	return dirs.workspaces
+}


### PR DESCRIPTION
Makes it easier to override in tests and separates missing environment variable errors from path generation.

Moved build roots to be created underneath `$XDG_CACHE_HOME`.

Fixes ch-1401
Fixes ch-2567