### PR TITLE
Separate out container IP expansion from BuildData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog][], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Unreleased]: https://github.com/yourbase/yb/compare/v0.4.0...HEAD
 
+## [Unreleased][]
+
+### Changed
+
+-  Attempting to use an unknown container in `{{.Container.IP}}` substitutions
+   will now cause a build failure rather than silently expanding to the
+   empty string.
+
+### Fixed
+
+-  Fixed the `{{.Container.IP}}` regression introduced in v0.4.0.
+
 ## [0.4.0][] - 2020-10-12
 
 Version 0.4 removes some broken or ill-conceived functionality from yb and

--- a/cli/build_test.go
+++ b/cli/build_test.go
@@ -1,0 +1,78 @@
+// Copyright 2020 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import "testing"
+
+func TestConfigExpansion(t *testing.T) {
+	tests := []struct {
+		name      string
+		exp       configExpansion
+		value     string
+		want      string
+		wantError bool
+	}{
+		{
+			name:  "NoExpansion",
+			value: "foo",
+			want:  "foo",
+		},
+		{
+			name: "ExpandContainerIP",
+			exp: configExpansion{
+				Containers: containersExpansion{
+					ips: map[string]string{
+						"postgres": "12.34.56.78",
+					},
+				},
+			},
+			value: `{{ .Containers.IP "postgres" }}`,
+			want:  "12.34.56.78",
+		},
+		{
+			name: "ExpandUnknownContainerIP",
+			exp: configExpansion{
+				Containers: containersExpansion{
+					ips: map[string]string{
+						"postgres": "12.34.56.78",
+					},
+				},
+			},
+			value:     `{{ .Containers.IP "foo" }}`,
+			wantError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.exp.expand(test.value)
+			if err != nil {
+				t.Logf("exp.expand(%q) = _, %v", test.value, err)
+				if !test.wantError {
+					t.Fail()
+				}
+				return
+			}
+			if got != test.want || test.wantError {
+				errString := "<nil>"
+				if test.wantError {
+					errString = "<error>"
+				}
+				t.Errorf("exp.expand(%q) = %q, %v; want %q, %s", test.value, got, err, test.want, errString)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I broke a number of builds in v0.4 because the signature of the `BuildData.IP` method changed to include a `context.Context`. It was not obvious that this would cause a breakage.

To prevent this from occurring in the future, I've introduced a new type that is intentionally very limited in what it exports and prominently documented what can't change. I've introduced unit tests that ensure that such substitutions will continue to work.

I have surveyed build configurations run against our CI to confirm that no other symbols in `BuildData` are being used, just `.Containers.IP`.

Fixes ch-2741