### PR TITLE
Move download functions into ybdata package

### DIFF
--- a/internal/buildpack/anaconda.go
+++ b/internal/buildpack/anaconda.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/blang/semver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -63,7 +64,7 @@ func (bt anacondaBuildTool) install(ctx context.Context) error {
 		}
 
 		log.Infof(ctx, "Downloading Miniconda from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v\n", err)
 			return err

--- a/internal/buildpack/android_ndk.go
+++ b/internal/buildpack/android_ndk.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -87,7 +88,7 @@ func (bt androidNDKBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Android NDK v%s from URL %s...", bt.version, downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/android_sdk.go
+++ b/internal/buildpack/android_sdk.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -142,7 +143,7 @@ func (bt androidBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Android from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/ant.go
+++ b/internal/buildpack/ant.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -84,7 +85,7 @@ func (bt antBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Ant from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/dart.go
+++ b/internal/buildpack/dart.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -94,7 +95,7 @@ func (bt dartBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Dart from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/flutter.go
+++ b/internal/buildpack/flutter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/johnewart/archiver"
 	"golang.org/x/mod/semver"
 
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -117,7 +118,7 @@ func (bt flutterBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Flutter from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/glide.go
+++ b/internal/buildpack/glide.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -70,7 +71,7 @@ func (bt glideBuildTool) install(ctx context.Context) error {
 		}
 
 		log.Infof(ctx, "Downloading from URL %s ...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/golang.go
+++ b/internal/buildpack/golang.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -93,7 +94,7 @@ func (bt golangBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading from URL %s ...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/gradle.go
+++ b/internal/buildpack/gradle.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -93,7 +94,7 @@ func (bt gradleBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Gradle from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/heroku.go
+++ b/internal/buildpack/heroku.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -85,7 +86,7 @@ func (bt herokuBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Heroku from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/maven.go
+++ b/internal/buildpack/maven.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
-	"github.com/yourbase/yb/plumbing"
+	"github.com/yourbase/yb/internal/ybdata"
 	"zombiezen.com/go/log"
 )
 
@@ -79,7 +79,7 @@ func (bt mavenBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading Maven from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/nodejs.go
+++ b/internal/buildpack/nodejs.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -62,7 +63,7 @@ func (bt nodeBuildTool) install(ctx context.Context) error {
 		archiveFile := fmt.Sprintf("%s.tar.gz", nodePkgString)
 		downloadURL := fmt.Sprintf("%s/v%s/%s", nodeDistMirror, bt.version, archiveFile)
 		log.Infof(ctx, "Downloading from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/openjdk.go
+++ b/internal/buildpack/openjdk.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -218,7 +219,7 @@ func (bt javaBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL(ctx)
 
 		log.Infof(ctx, "Downloading from URL %s ", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/protoc.go
+++ b/internal/buildpack/protoc.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -97,7 +98,7 @@ func (bt protocBuildTool) install(ctx context.Context) error {
 	downloadURL := bt.downloadURL()
 
 	log.Infof(ctx, "Downloading Protoc from URL %s...", downloadURL)
-	localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+	localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 	if err != nil {
 		log.Errorf(ctx, "Unable to download: %v", err)
 		return err

--- a/internal/buildpack/python.go
+++ b/internal/buildpack/python.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -50,7 +51,7 @@ func (bt pythonBuildTool) install(ctx context.Context) error {
 		}
 
 		log.Infof(ctx, "Downloading Miniconda from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/rlang.go
+++ b/internal/buildpack/rlang.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -79,7 +80,7 @@ func (bt rLangBuildTool) install(ctx context.Context) error {
 		downloadURL := bt.downloadURL()
 
 		log.Infof(ctx, "Downloading from URL %s ...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/ruby.go
+++ b/internal/buildpack/ruby.go
@@ -12,6 +12,7 @@ import (
 	"github.com/johnewart/archiver"
 	"github.com/matishsiao/goInfo"
 
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"gopkg.in/src-d/go-git.v4"
 	"zombiezen.com/go/log"
@@ -121,7 +122,7 @@ func (bt rubyBuildTool) install(ctx context.Context) error {
 			downloadURL := bt.downloadURL(ctx)
 			log.Infof(ctx, "Will download pre-built Ruby from %s", downloadURL)
 
-			localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+			localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 			if err != nil {
 				log.Errorf(ctx, "Unable to download: %v", err)
 				return err

--- a/internal/buildpack/rust.go
+++ b/internal/buildpack/rust.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -69,9 +70,7 @@ func (bt rustBuildTool) install(ctx context.Context) error {
 		downloadURL := fmt.Sprintf("%s/%s-%s/%s", rustDistMirror, arch, operatingSystem, installerFile)
 
 		downloadDir := bt.spec.cacheDir
-		localFile := filepath.Join(downloadDir, installerFile)
-		log.Infof(ctx, "Downloading from URL %s to local file %s", downloadURL, localFile)
-		err := plumbing.DownloadFile(ctx, http.DefaultClient, localFile, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			log.Errorf(ctx, "Unable to download: %v", err)
 			return err

--- a/internal/buildpack/yarn.go
+++ b/internal/buildpack/yarn.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/johnewart/archiver"
+	"github.com/yourbase/yb/internal/ybdata"
 	"github.com/yourbase/yb/plumbing"
 	"zombiezen.com/go/log"
 )
@@ -58,7 +59,7 @@ func (bt yarnBuildTool) install(ctx context.Context) error {
 		log.Infof(ctx, "Will install Yarn v%s into %s", bt.version, installDir)
 		downloadURL := bt.downloadURL()
 		log.Infof(ctx, "Downloading from URL %s...", downloadURL)
-		localFile, err := plumbing.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
+		localFile, err := ybdata.DownloadFileWithCache(ctx, http.DefaultClient, bt.spec.dataDirs, downloadURL)
 		if err != nil {
 			return fmt.Errorf("Unable to download %s: %v", downloadURL, err)
 		}

--- a/internal/ybdata/download.go
+++ b/internal/ybdata/download.go
@@ -1,0 +1,178 @@
+// Copyright 2020 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ybdata
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/yourbase/yb/internal/ybtrace"
+	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/label"
+	"zombiezen.com/go/log"
+)
+
+func download(ctx context.Context, client *http.Client, dst io.Writer, url string) (err error) {
+	ctx, span := ybtrace.Start(ctx, "Download "+url,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			label.String("http.method", http.MethodGet),
+			label.String("http.url", url),
+		),
+	)
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Unknown, err.Error())
+		}
+		span.End()
+	}()
+
+	// Make HTTP request.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	log.Infof(ctx, "Downloading %s", url)
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	span.SetAttribute("http.status_code", resp.StatusCode)
+	span.SetAttribute("http.response_content_length", resp.ContentLength)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: HTTP %s", url, resp.Status)
+	}
+
+	// Copy to file.
+	if _, err := io.Copy(dst, resp.Body); err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	return nil
+}
+
+// Download downloads a URL to the local filesystem and returns a handle to
+// the file. Download maintains a cache in dataDirs.
+func Download(ctx context.Context, client *http.Client, dataDirs *Dirs, url string) (_ *os.File, err error) {
+	cacheFilename := filepath.Join(dataDirs.Downloads(), cacheFilenameForURL(url))
+	if err := os.MkdirAll(filepath.Dir(cacheFilename), 0777); err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	// Create file first, since that requires less work to fail faster.
+	f, err := os.OpenFile(cacheFilename, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	written := false
+	defer func() {
+		if err != nil {
+			f.Close()
+
+			if written {
+				// If there's an error, the cache has been made inconsistent because
+				// we've truncated the file. Remove the file to force a download later.
+				if err := os.Remove(cacheFilename); err != nil {
+					log.Warnf(ctx, "Failed to clean up failed download: %v", err)
+				}
+			}
+		}
+	}()
+
+	cacheErr := validateDownloadCache(ctx, client, f, url)
+	if cacheErr == nil {
+		log.Infof(ctx, "Reusing cached version of %s", url)
+		return f, nil
+	}
+	log.Infof(ctx, "Not using cache for %s: %v", url, cacheErr)
+	written = true
+	if err := f.Truncate(0); err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	if err := download(ctx, client, f, url); err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	return f, nil
+}
+
+// DownloadFileWithCache downloads a URL to the local filesystem and returns
+// the path to the downloaded copy.
+//
+// Deprecated: Use Download to avoid closing and reopening file.
+func DownloadFileWithCache(ctx context.Context, client *http.Client, dataDirs *Dirs, url string) (string, error) {
+	f, err := Download(ctx, client, dataDirs, url)
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	f.Close()
+	return path, nil
+}
+
+func validateDownloadCache(ctx context.Context, client *http.Client, statter interface{ Stat() (os.FileInfo, error) }, url string) (err error) {
+	ctx, span := ybtrace.Start(ctx, "Validate cache for "+url,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			label.String("http.method", http.MethodHead),
+			label.String("http.url", url),
+		),
+	)
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Unknown, err.Error())
+		}
+		span.End()
+	}()
+
+	info, err := statter.Stat()
+	if err != nil {
+		return fmt.Errorf("validate %s download cache: %w", url, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return fmt.Errorf("validate %s download cache: %w", url, err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("validate %s download cache: %w", url, err)
+	}
+	resp.Body.Close()
+	span.SetAttribute("http.status_code", resp.StatusCode)
+	span.SetAttribute("http.response_content_length", resp.ContentLength)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("validate %s download cache: HTTP %s", url, resp.Status)
+	}
+	if fileSize := info.Size(); fileSize != resp.ContentLength {
+		return fmt.Errorf("validate %s download cache: size %d does not match resource size %d", url, fileSize, resp.ContentLength)
+	}
+	return nil
+}
+
+var cacheFilenameUnsafeChars = regexp.MustCompile(`[^a-zA-Z0-9.]+`)
+
+func cacheFilenameForURL(url string) string {
+	// TODO(light): Use a hash-based scheme.
+	return cacheFilenameUnsafeChars.ReplaceAllString(url, "")
+}


### PR DESCRIPTION
Mostly a code motion, but also restructures the internals so there's only a single `open(2)` syscall. When I port the buildpacks, they will use the already-opened file rather than re-opening the path.

/cc @glacials