### PR TITLE
Fail build if Ruby install fails

### DIFF
--- a/internal/buildpack/ruby.go
+++ b/internal/buildpack/ruby.go
@@ -187,7 +187,10 @@ func (bt rubyBuildTool) install(ctx context.Context) error {
 		plumbing.PrependToPath(filepath.Join(rbenvDir, "bin"))
 
 		installCmd := fmt.Sprintf("rbenv install %s", bt.version)
-		plumbing.ExecToStdout(installCmd, rbenvDir)
+		if err := plumbing.ExecToStdout(installCmd, rbenvDir); err != nil {
+			log.Errorf(ctx, "Unable to install ruby!")
+			return fmt.Errorf("Couldn't install ruby: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Currently if the Ruby buildpack's Ruby install fails (e.g. because you specify a bad ruby version like `ruby:blah`), the build is still marked as successful. This branch changes the build to fail.