### PR TITLE
Upgrade Narwhal to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog][], and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
-[Unreleased]: https://github.com/yourbase/yb/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/yourbase/yb/compare/v0.4.3...HEAD
 
 ## [Unreleased][]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,19 @@ The format is based on [Keep a Changelog][], and this project adheres to
 -  The Ant buildpack now downloads over HTTPS from the sonic.net mirror. It was
    previously using the lucidnetworks.net mirror over HTTP.
 
+## [0.4.3][] - 2020-11-05
+
+Version 0.4.3 fixes an issue with containers in environments that don't have
+a `docker0` network like WSL and macOS.
+
+[0.4.3]: https://github.com/yourbase/yb/releases/tag/v0.4.3
+
+### Fixed
+
+-  Port wait checks will now automatically forward a port on any host that does
+   not have a `docker0` network. Previously, this behavior was only used on
+   macOS, but it is also applicable to Docker Desktop with WSL.
+
 ## [0.4.2][] - 2020-10-20
 
 Version 0.4.2 fixes an issue with `yb remotebuild`.

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/ulikunitz/xz v0.5.8
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yourbase/commons v0.6.0
-	github.com/yourbase/narwhal v0.5.3
+	github.com/yourbase/narwhal v0.6.1
 	go.opentelemetry.io/otel v0.11.0
 	go.opentelemetry.io/otel/sdk v0.11.0
 	go4.org v0.0.0-20200411211856-f5505b9728dd

--- a/go.sum
+++ b/go.sum
@@ -462,10 +462,11 @@ github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/yourbase/commons v0.1.0/go.mod h1:33VOfAZFfHwouAocNBqM9o5ZpCIwwSQq3vqjKpYK8sc=
 github.com/yourbase/commons v0.6.0 h1:v77YBV6TL4TL+0vnop6LaTOhzCQJACpED4lXVhyK2Ps=
 github.com/yourbase/commons v0.6.0/go.mod h1:Puc7zTNtP4J7cRK9LkAUWYdORUQ0f7ZcgFFu2lxOe4Y=
-github.com/yourbase/narwhal v0.5.3 h1:qJzTSuM/5Wf3XQFQLdEGW0af/Kjt1UIsyW6hlgzqZCU=
-github.com/yourbase/narwhal v0.5.3/go.mod h1:E3CDnwheEjNSYK+ISGCoE805lBzm+qfG2tDA5M1s+mk=
+github.com/yourbase/narwhal v0.6.1 h1:kRdEXM1bRm2zPEx9Y+bg/DhLifxYvz3faeAXlm6rjgI=
+github.com/yourbase/narwhal v0.6.1/go.mod h1:X1FC2daND8bK/vrhDsa00VtR4vnwYcmPUAzKF/FXdyw=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=


### PR DESCRIPTION
Picks up fixes to port wait checks.

Fixes ch-2953