### PR TITLE
Run Rust installer in buildpack

### DIFF
--- a/internal/buildpack/testdata/TestRust/darwin_amd64.json
+++ b/internal/buildpack/testdata/TestRust/darwin_amd64.json
@@ -4,50 +4,48 @@
 		"Arch": "amd64"
 	},
 	"Dirs": {
-		"Package": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/001",
-		"Home": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002",
-		"Tools": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools"
+		"Package": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/001",
+		"Home": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002",
+		"Tools": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools"
 	},
 	"JoinedPaths": [
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools",
 				"rust",
 				"rust-1.43.1"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002",
 				"cargohome"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/cargohome"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/cargohome"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1",
-				"cargo",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1",
 				"bin"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1/cargo/bin"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1/bin"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1",
-				"rustc",
-				"bin"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download",
+				"install.sh"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1/rustc/bin"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download/install.sh"
 		}
 	],
 	"CleanedPaths": {
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1",
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz"
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download",
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz"
 	},
 	"AbsPaths": {
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1": true,
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz": true
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download": true,
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz": true
 	},
 	"Invocations": [
 		{
@@ -55,11 +53,11 @@
 				"python",
 				"-c",
 				"import os, sys; os.stat(sys.argv[1]); sys.stdout.write(os.path.realpath(sys.argv[1]))",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1"
 			],
 			"Output": {
 				"Stdout": "",
-				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVzdDkyMTc4ODMwNy8wMDIvLmNhY2hlL3liL3Rvb2xzL3J1c3QvcnVzdC0xLjQzLjEnCg=="
+				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVzdDQ2OTc3MDA0Mi8wMDIvLmNhY2hlL3liL3Rvb2xzL3J1c3QvcnVzdC0xLjQzLjEnCg=="
 			},
 			"Error": "local run: exit status 1"
 		},
@@ -67,7 +65,7 @@
 			"Argv": [
 				"mkdir",
 				"-p",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download"
 			],
 			"Output": {
 				"Stderr": ""
@@ -76,7 +74,7 @@
 		{
 			"Argv": [
 				"tee",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz"
 			],
 			"StdinSHA256": "e1c3e1426a9e615079159d6b619319235e3ca7b395e7603330375bfffcbb7003",
 			"Output": {
@@ -89,11 +87,11 @@
 				"-x",
 				"-z",
 				"-f",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz",
 				"--strip-components",
 				"1"
 			],
-			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1",
+			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download",
 			"Output": {
 				"Combined": ""
 			}
@@ -102,10 +100,20 @@
 			"Argv": [
 				"rm",
 				"-f",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz"
 			],
 			"Output": {
 				"Combined": ""
+			}
+		},
+		{
+			"Argv": [
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download/install.sh",
+				"--prefix=/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1"
+			],
+			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1-download",
+			"Output": {
+				"Combined": "aW5zdGFsbDogY3JlYXRpbmcgdW5pbnN0YWxsIHNjcmlwdCBhdCAvdmFyL2ZvbGRlcnMvZ2wvOGt4YzF6eDU3NGIyeWJqdHZ4aDQ3ank0MDAwMGtrL1QvVGVzdFJ1c3Q0Njk3NzAwNDIvMDAyLy5jYWNoZS95Yi90b29scy9ydXN0L3J1c3QtMS40My4xL2xpYi9ydXN0bGliL3VuaW5zdGFsbC5zaAppbnN0YWxsOiBpbnN0YWxsaW5nIGNvbXBvbmVudCAncnVzdGMnCmluc3RhbGw6IGluc3RhbGxpbmcgY29tcG9uZW50ICdjYXJnbycKaW5zdGFsbDogaW5zdGFsbGluZyBjb21wb25lbnQgJ3Jscy1wcmV2aWV3JwppbnN0YWxsOiBpbnN0YWxsaW5nIGNvbXBvbmVudCAnY2xpcHB5LXByZXZpZXcnCmluc3RhbGw6IGluc3RhbGxpbmcgY29tcG9uZW50ICdtaXJpLXByZXZpZXcnCmluc3RhbGw6IGluc3RhbGxpbmcgY29tcG9uZW50ICdydXN0Zm10LXByZXZpZXcnCmluc3RhbGw6IGluc3RhbGxpbmcgY29tcG9uZW50ICdsbHZtLXRvb2xzLXByZXZpZXcnCmluc3RhbGw6IGluc3RhbGxpbmcgY29tcG9uZW50ICdydXN0LWFuYWx5c2lzLXg4Nl82NC1hcHBsZS1kYXJ3aW4nCmluc3RhbGw6IGluc3RhbGxpbmcgY29tcG9uZW50ICdydXN0LXN0ZC14ODZfNjQtYXBwbGUtZGFyd2luJwppbnN0YWxsOiBpbnN0YWxsaW5nIGNvbXBvbmVudCAncnVzdC1kb2NzJwoKICAgIFJ1c3QgaXMgcmVhZHkgdG8gcm9sbC4KCg=="
 			}
 		},
 		{
@@ -114,11 +122,10 @@
 				"--version"
 			],
 			"EnvVars": {
-				"CARGO_HOME": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/cargohome"
+				"CARGO_HOME": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/cargohome"
 			},
 			"PrependPath": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1/cargo/bin",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1/rustc/bin"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1/bin"
 			],
 			"Output": {
 				"Combined": "cnVzdGMgMS40My4xICg4ZDY5ODQwYWIgMjAyMC0wNS0wNCkK"
@@ -130,11 +137,10 @@
 				"--version"
 			],
 			"EnvVars": {
-				"CARGO_HOME": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/cargohome"
+				"CARGO_HOME": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/cargohome"
 			},
 			"PrependPath": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1/cargo/bin",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust921788307/002/.cache/yb/tools/rust/rust-1.43.1/rustc/bin"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRust469770042/002/.cache/yb/tools/rust/rust-1.43.1/bin"
 			],
 			"Output": {
 				"Combined": "Y2FyZ28gMS40My4wICgyY2JlOTA0OGUgMjAyMC0wNS0wMykK"

--- a/internal/buildpack/testdata/TestRust/linux_amd64.json
+++ b/internal/buildpack/testdata/TestRust/linux_amd64.json
@@ -4,50 +4,48 @@
 		"Arch": "amd64"
 	},
 	"Dirs": {
-		"Package": "/tmp/TestRust899693908/001",
-		"Home": "/tmp/TestRust899693908/002",
-		"Tools": "/tmp/TestRust899693908/002/.cache/yb/tools"
+		"Package": "/tmp/TestRust801473782/001",
+		"Home": "/tmp/TestRust801473782/002",
+		"Tools": "/tmp/TestRust801473782/002/.cache/yb/tools"
 	},
 	"JoinedPaths": [
 		{
 			"Elems": [
-				"/tmp/TestRust899693908/002/.cache/yb/tools",
+				"/tmp/TestRust801473782/002/.cache/yb/tools",
 				"rust",
 				"rust-1.43.1"
 			],
-			"Result": "/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1"
+			"Result": "/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1"
 		},
 		{
 			"Elems": [
-				"/tmp/TestRust899693908/002",
+				"/tmp/TestRust801473782/002",
 				"cargohome"
 			],
-			"Result": "/tmp/TestRust899693908/002/cargohome"
+			"Result": "/tmp/TestRust801473782/002/cargohome"
 		},
 		{
 			"Elems": [
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1",
-				"cargo",
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1",
 				"bin"
 			],
-			"Result": "/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1/cargo/bin"
+			"Result": "/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1/bin"
 		},
 		{
 			"Elems": [
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1",
-				"rustc",
-				"bin"
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download",
+				"install.sh"
 			],
-			"Result": "/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1/rustc/bin"
+			"Result": "/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download/install.sh"
 		}
 	],
 	"CleanedPaths": {
-		"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1": "/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1",
-		"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz": "/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz"
+		"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download": "/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download",
+		"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz": "/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz"
 	},
 	"AbsPaths": {
-		"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1": true,
-		"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz": true
+		"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download": true,
+		"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz": true
 	},
 	"Invocations": [
 		{
@@ -55,7 +53,7 @@
 				"readlink",
 				"--canonicalize-existing",
 				"--no-newline",
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1"
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1"
 			],
 			"Output": {
 				"Stdout": "",
@@ -67,7 +65,7 @@
 			"Argv": [
 				"mkdir",
 				"-p",
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1"
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download"
 			],
 			"Output": {
 				"Stderr": ""
@@ -76,7 +74,7 @@
 		{
 			"Argv": [
 				"tee",
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz"
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz"
 			],
 			"StdinSHA256": "25cd71b95bba0daef56bad8c943a87368c4185b90983f4412f46e3e2418c0505",
 			"Output": {
@@ -89,11 +87,11 @@
 				"-x",
 				"-z",
 				"-f",
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz",
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz",
 				"--strip-components",
 				"1"
 			],
-			"Dir": "/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1",
+			"Dir": "/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download",
 			"Output": {
 				"Combined": ""
 			}
@@ -102,10 +100,20 @@
 			"Argv": [
 				"rm",
 				"-f",
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1.tar.gz"
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download.tar.gz"
 			],
 			"Output": {
 				"Combined": ""
+			}
+		},
+		{
+			"Argv": [
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download/install.sh",
+				"--prefix=/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1"
+			],
+			"Dir": "/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1-download",
+			"Output": {
+				"Combined": "aW5zdGFsbDogY3JlYXRpbmcgdW5pbnN0YWxsIHNjcmlwdCBhdCAvdG1wL1Rlc3RSdXN0ODAxNDczNzgyLzAwMi8uY2FjaGUveWIvdG9vbHMvcnVzdC9ydXN0LTEuNDMuMS9saWIvcnVzdGxpYi91bmluc3RhbGwuc2gKaW5zdGFsbDogaW5zdGFsbGluZyBjb21wb25lbnQgJ3J1c3RjJwppbnN0YWxsOiBpbnN0YWxsaW5nIGNvbXBvbmVudCAnY2FyZ28nCmluc3RhbGw6IGluc3RhbGxpbmcgY29tcG9uZW50ICdybHMtcHJldmlldycKaW5zdGFsbDogaW5zdGFsbGluZyBjb21wb25lbnQgJ2NsaXBweS1wcmV2aWV3JwppbnN0YWxsOiBpbnN0YWxsaW5nIGNvbXBvbmVudCAnbWlyaS1wcmV2aWV3JwppbnN0YWxsOiBpbnN0YWxsaW5nIGNvbXBvbmVudCAncnVzdGZtdC1wcmV2aWV3JwppbnN0YWxsOiBpbnN0YWxsaW5nIGNvbXBvbmVudCAnbGx2bS10b29scy1wcmV2aWV3JwppbnN0YWxsOiBpbnN0YWxsaW5nIGNvbXBvbmVudCAncnVzdC1hbmFseXNpcy14ODZfNjQtdW5rbm93bi1saW51eC1nbnUnCmluc3RhbGw6IGluc3RhbGxpbmcgY29tcG9uZW50ICdydXN0LXN0ZC14ODZfNjQtdW5rbm93bi1saW51eC1nbnUnCmluc3RhbGw6IGluc3RhbGxpbmcgY29tcG9uZW50ICdydXN0LWRvY3MnCmluc3RhbGw6IFdBUk5JTkc6IGZhaWxlZCB0byBydW4gbGRjb25maWcuIHRoaXMgbWF5IGhhcHBlbiB3aGVuIG5vdCBpbnN0YWxsaW5nIGFzIHJvb3QuIHJ1biB3aXRoIC0tdmVyYm9zZSB0byBzZWUgdGhlIGVycm9yCgogICAgUnVzdCBpcyByZWFkeSB0byByb2xsLgoK"
 			}
 		},
 		{
@@ -114,11 +122,10 @@
 				"--version"
 			],
 			"EnvVars": {
-				"CARGO_HOME": "/tmp/TestRust899693908/002/cargohome"
+				"CARGO_HOME": "/tmp/TestRust801473782/002/cargohome"
 			},
 			"PrependPath": [
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1/cargo/bin",
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1/rustc/bin"
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1/bin"
 			],
 			"Output": {
 				"Combined": "cnVzdGMgMS40My4xICg4ZDY5ODQwYWIgMjAyMC0wNS0wNCkK"
@@ -130,11 +137,10 @@
 				"--version"
 			],
 			"EnvVars": {
-				"CARGO_HOME": "/tmp/TestRust899693908/002/cargohome"
+				"CARGO_HOME": "/tmp/TestRust801473782/002/cargohome"
 			},
 			"PrependPath": [
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1/cargo/bin",
-				"/tmp/TestRust899693908/002/.cache/yb/tools/rust/rust-1.43.1/rustc/bin"
+				"/tmp/TestRust801473782/002/.cache/yb/tools/rust/rust-1.43.1/bin"
 			],
 			"Output": {
 				"Combined": "Y2FyZ28gMS40My4wICgyY2JlOTA0OGUgMjAyMC0wNS0wMykK"


### PR DESCRIPTION
Otherwise, builds will run but the standard library crate can't be found. QA'd by running against a real Rust project.