### PR TITLE
Set GOROOT in Go buildpack

### DIFF
--- a/internal/buildpack/golang.go
+++ b/internal/buildpack/golang.go
@@ -15,6 +15,7 @@ func installGo(ctx context.Context, sys Sys, spec yb.BuildpackSpec) (biome.Envir
 	gopathDir := sys.Biome.JoinPath(golangRoot, "gopath")
 	env := biome.Environment{
 		Vars: map[string]string{
+			"GOROOT": golangDir,
 			"GOPATH": gopathDir + ":" + sys.Biome.Dirs().Package,
 		},
 		PrependPath: []string{

--- a/internal/buildpack/testdata/TestGo/darwin_amd64.json
+++ b/internal/buildpack/testdata/TestGo/darwin_amd64.json
@@ -4,47 +4,47 @@
 		"Arch": "amd64"
 	},
 	"Dirs": {
-		"Package": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/001",
-		"Home": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002",
-		"Tools": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools"
+		"Package": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/001",
+		"Home": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002",
+		"Tools": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools"
 	},
 	"JoinedPaths": [
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools",
 				"go"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go",
 				"go1.15.2"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go",
 				"gopath"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/gopath"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/gopath"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2",
 				"bin"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2/bin"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2/bin"
 		}
 	],
 	"CleanedPaths": {
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2",
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2.tar.gz": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2.tar.gz"
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2",
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2.tar.gz": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2.tar.gz"
 	},
 	"AbsPaths": {
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2": true,
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2.tar.gz": true
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2": true,
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2.tar.gz": true
 	},
 	"Invocations": [
 		{
@@ -52,11 +52,11 @@
 				"python",
 				"-c",
 				"import os, sys; os.stat(sys.argv[1]); sys.stdout.write(os.path.realpath(sys.argv[1]))",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2"
 			],
 			"Output": {
 				"Stdout": "",
-				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0R280NDM1MzQxMjkvMDAyLy5jYWNoZS95Yi90b29scy9nby9nbzEuMTUuMicK"
+				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0R280OTUyNDU5MTMvMDAyLy5jYWNoZS95Yi90b29scy9nby9nbzEuMTUuMicK"
 			},
 			"Error": "local run: exit status 1"
 		},
@@ -64,7 +64,7 @@
 			"Argv": [
 				"mkdir",
 				"-p",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2"
 			],
 			"Output": {
 				"Stderr": ""
@@ -73,7 +73,7 @@
 		{
 			"Argv": [
 				"tee",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2.tar.gz"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2.tar.gz"
 			],
 			"StdinSHA256": "9bd39600d9fa1fa4a5ccce8761d249f7421cffe671376f791293c4138f3d7c62",
 			"Output": {
@@ -86,11 +86,11 @@
 				"-x",
 				"-z",
 				"-f",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2.tar.gz",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2.tar.gz",
 				"--strip-components",
 				"1"
 			],
-			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2",
+			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2",
 			"Output": {
 				"Combined": ""
 			}
@@ -99,7 +99,7 @@
 			"Argv": [
 				"rm",
 				"-f",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2.tar.gz"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2.tar.gz"
 			],
 			"Output": {
 				"Combined": ""
@@ -111,11 +111,12 @@
 				"version"
 			],
 			"EnvVars": {
-				"GOPATH": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/gopath:/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/001"
+				"GOPATH": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/gopath:/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/001",
+				"GOROOT": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2"
 			},
 			"PrependPath": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/gopath",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo443534129/002/.cache/yb/tools/go/go1.15.2/bin"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/gopath",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestGo495245913/002/.cache/yb/tools/go/go1.15.2/bin"
 			],
 			"Output": {
 				"Combined": "Z28gdmVyc2lvbiBnbzEuMTUuMiBkYXJ3aW4vYW1kNjQK"

--- a/internal/buildpack/testdata/TestGo/linux_amd64.json
+++ b/internal/buildpack/testdata/TestGo/linux_amd64.json
@@ -4,47 +4,47 @@
 		"Arch": "amd64"
 	},
 	"Dirs": {
-		"Package": "/tmp/TestGo873929066/001",
-		"Home": "/tmp/TestGo873929066/002",
-		"Tools": "/tmp/TestGo873929066/002/.cache/yb/tools"
+		"Package": "/tmp/TestGo037641266/001",
+		"Home": "/tmp/TestGo037641266/002",
+		"Tools": "/tmp/TestGo037641266/002/.cache/yb/tools"
 	},
 	"JoinedPaths": [
 		{
 			"Elems": [
-				"/tmp/TestGo873929066/002/.cache/yb/tools",
+				"/tmp/TestGo037641266/002/.cache/yb/tools",
 				"go"
 			],
-			"Result": "/tmp/TestGo873929066/002/.cache/yb/tools/go"
+			"Result": "/tmp/TestGo037641266/002/.cache/yb/tools/go"
 		},
 		{
 			"Elems": [
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go",
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go",
 				"go1.15.2"
 			],
-			"Result": "/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2"
+			"Result": "/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2"
 		},
 		{
 			"Elems": [
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go",
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go",
 				"gopath"
 			],
-			"Result": "/tmp/TestGo873929066/002/.cache/yb/tools/go/gopath"
+			"Result": "/tmp/TestGo037641266/002/.cache/yb/tools/go/gopath"
 		},
 		{
 			"Elems": [
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2",
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2",
 				"bin"
 			],
-			"Result": "/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2/bin"
+			"Result": "/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2/bin"
 		}
 	],
 	"CleanedPaths": {
-		"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2": "/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2",
-		"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2.tar.gz": "/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2.tar.gz"
+		"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2": "/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2",
+		"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2.tar.gz": "/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2.tar.gz"
 	},
 	"AbsPaths": {
-		"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2": true,
-		"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2.tar.gz": true
+		"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2": true,
+		"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2.tar.gz": true
 	},
 	"Invocations": [
 		{
@@ -52,7 +52,7 @@
 				"readlink",
 				"--canonicalize-existing",
 				"--no-newline",
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2"
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2"
 			],
 			"Output": {
 				"Stdout": "",
@@ -64,7 +64,7 @@
 			"Argv": [
 				"mkdir",
 				"-p",
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2"
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2"
 			],
 			"Output": {
 				"Stderr": ""
@@ -73,7 +73,7 @@
 		{
 			"Argv": [
 				"tee",
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2.tar.gz"
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2.tar.gz"
 			],
 			"StdinSHA256": "b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552",
 			"Output": {
@@ -86,11 +86,11 @@
 				"-x",
 				"-z",
 				"-f",
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2.tar.gz",
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2.tar.gz",
 				"--strip-components",
 				"1"
 			],
-			"Dir": "/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2",
+			"Dir": "/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2",
 			"Output": {
 				"Combined": ""
 			}
@@ -99,7 +99,7 @@
 			"Argv": [
 				"rm",
 				"-f",
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2.tar.gz"
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2.tar.gz"
 			],
 			"Output": {
 				"Combined": ""
@@ -111,11 +111,12 @@
 				"version"
 			],
 			"EnvVars": {
-				"GOPATH": "/tmp/TestGo873929066/002/.cache/yb/tools/go/gopath:/tmp/TestGo873929066/001"
+				"GOPATH": "/tmp/TestGo037641266/002/.cache/yb/tools/go/gopath:/tmp/TestGo037641266/001",
+				"GOROOT": "/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2"
 			},
 			"PrependPath": [
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go/gopath",
-				"/tmp/TestGo873929066/002/.cache/yb/tools/go/go1.15.2/bin"
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go/gopath",
+				"/tmp/TestGo037641266/002/.cache/yb/tools/go/go1.15.2/bin"
 			],
 			"Output": {
 				"Combined": "Z28gdmVyc2lvbiBnbzEuMTUuMiBsaW51eC9hbWQ2NAo="


### PR DESCRIPTION
The Go binary distributions have their implicit `GOROOT` set to `/usr/local/go`, which is not where we install the buildpack. This can cause build issues in some scenarios.