### PR TITLE
Automate Narwhal updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "daily"
     allow:
+      - dependency-name: "github.com/yourbase/commons"
       - dependency-name: "github.com/yourbase/narwhal"
     reviewers:
       - "zombiezen"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "github.com/yourbase/narwhal"
+    reviewers:
+      - "zombiezen"


### PR DESCRIPTION
Shortest interval is daily, so if we ever want a fast turnaround we'll still have to do it ourselves.