### PR TITLE
Pin the rbenv version in the Ruby buildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog][], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Unreleased]: https://github.com/yourbase/yb/compare/v0.5.0...HEAD
 
+## [Unreleased][]
+
+### Fixed
+
+-  The Ruby buildpack downloads a pinned version of rbenv and ruby-build rather
+   than following the latest commit.
+
 ## [0.5.0][] - 2020-11-18
 
 Version 0.5 provides better reproducibility and isolation than previous

--- a/internal/buildpack/ruby.go
+++ b/internal/buildpack/ruby.go
@@ -77,7 +77,7 @@ func installRuby(ctx context.Context, sys Sys, spec yb.BuildpackSpec) (biome.Env
 	if _, err := biome.EvalSymlinks(ctx, sys.Biome, rbenvDir); err != nil {
 		log.Debugf(ctx, "rbenv not found: %v", err)
 		log.Infof(ctx, "Installing rbenv in %s", rbenvDir)
-		err := extract(ctx, sys, rbenvDir, "https://github.com/rbenv/rbenv/archive/master.zip", stripTopDirectory)
+		err := extract(ctx, sys, rbenvDir, "https://github.com/rbenv/rbenv/archive/60c933968584ac9ae7caac6dbed614740f899ec3.zip", stripTopDirectory)
 		if err != nil {
 			return biome.Environment{}, fmt.Errorf("download rbenv: %w", err)
 		}
@@ -86,7 +86,7 @@ func installRuby(ctx context.Context, sys Sys, spec yb.BuildpackSpec) (biome.Env
 	if _, err := biome.EvalSymlinks(ctx, sys.Biome, rubyBuildDir); err != nil {
 		log.Debugf(ctx, "ruby-build not found: %v", err)
 		log.Infof(ctx, "Installing ruby-build plugin in %s", rubyBuildDir)
-		err := extract(ctx, sys, rubyBuildDir, "https://github.com/rbenv/ruby-build/archive/master.zip", stripTopDirectory)
+		err := extract(ctx, sys, rubyBuildDir, "https://github.com/rbenv/ruby-build/archive/v20201118.zip", stripTopDirectory)
 		if err != nil {
 			return biome.Environment{}, fmt.Errorf("download ruby-build plugin: %w", err)
 		}

--- a/internal/buildpack/testdata/TestRuby/darwin_amd64.json
+++ b/internal/buildpack/testdata/TestRuby/darwin_amd64.json
@@ -4,277 +4,277 @@
 		"Arch": "amd64"
 	},
 	"Dirs": {
-		"Package": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/001",
-		"Home": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002",
-		"Tools": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools"
+		"Package": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/001",
+		"Home": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002",
+		"Tools": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools"
 	},
 	"JoinedPaths": [
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools",
 				"rbenv"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv",
 				"versions",
 				"2.6.3"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/versions/2.6.3"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/versions/2.6.3"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002",
 				"rubygems"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/rubygems"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/rubygems"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/rubygems",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/rubygems",
 				"bin"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/rubygems/bin"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/rubygems/bin"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/versions/2.6.3",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/versions/2.6.3",
 				"bin"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/versions/2.6.3/bin"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/versions/2.6.3/bin"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv.zip"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv.zip"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv.zip"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv.zip"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				".github"
 			],
-			"Result": "rbenv-master/.github"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/.github"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				".gitignore"
 			],
-			"Result": "rbenv-master/.gitignore"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/.gitignore"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				".vimrc"
 			],
-			"Result": "rbenv-master/.vimrc"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/.vimrc"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				"CODE_OF_CONDUCT.md"
 			],
-			"Result": "rbenv-master/CODE_OF_CONDUCT.md"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/CODE_OF_CONDUCT.md"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				"LICENSE"
 			],
-			"Result": "rbenv-master/LICENSE"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/LICENSE"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				"README.md"
 			],
-			"Result": "rbenv-master/README.md"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/README.md"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				"bin"
 			],
-			"Result": "rbenv-master/bin"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/bin"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				"completions"
 			],
-			"Result": "rbenv-master/completions"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/completions"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				"libexec"
 			],
-			"Result": "rbenv-master/libexec"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/libexec"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				"rbenv.d"
 			],
-			"Result": "rbenv-master/rbenv.d"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/rbenv.d"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				"src"
 			],
-			"Result": "rbenv-master/src"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/src"
 		},
 		{
 			"Elems": [
-				"rbenv-master",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3",
 				"test"
 			],
-			"Result": "rbenv-master/test"
+			"Result": "rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/test"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv",
 				"plugins",
 				"ruby-build"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				".github"
 			],
-			"Result": "ruby-build-master/.github"
+			"Result": "ruby-build-20201118/.github"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				".gitignore"
 			],
-			"Result": "ruby-build-master/.gitignore"
+			"Result": "ruby-build-20201118/.gitignore"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				".travis.yml"
 			],
-			"Result": "ruby-build-master/.travis.yml"
+			"Result": "ruby-build-20201118/.travis.yml"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				"CODE_OF_CONDUCT.md"
 			],
-			"Result": "ruby-build-master/CODE_OF_CONDUCT.md"
+			"Result": "ruby-build-20201118/CODE_OF_CONDUCT.md"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				"LICENSE"
 			],
-			"Result": "ruby-build-master/LICENSE"
+			"Result": "ruby-build-20201118/LICENSE"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				"README.md"
 			],
-			"Result": "ruby-build-master/README.md"
+			"Result": "ruby-build-20201118/README.md"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				"bin"
 			],
-			"Result": "ruby-build-master/bin"
+			"Result": "ruby-build-20201118/bin"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				"install.sh"
 			],
-			"Result": "ruby-build-master/install.sh"
+			"Result": "ruby-build-20201118/install.sh"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				"script"
 			],
-			"Result": "ruby-build-master/script"
+			"Result": "ruby-build-20201118/script"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				"share"
 			],
-			"Result": "ruby-build-master/share"
+			"Result": "ruby-build-20201118/share"
 		},
 		{
 			"Elems": [
-				"ruby-build-master",
+				"ruby-build-20201118",
 				"test"
 			],
-			"Result": "ruby-build-master/test"
+			"Result": "ruby-build-20201118/test"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build"
 		},
 		{
 			"Elems": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv",
 				"bin"
 			],
-			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/bin"
+			"Result": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/bin"
 		}
 	],
 	"AbsPaths": {
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv": true,
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv.zip": true,
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build": true,
-		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip": true
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv": true,
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv.zip": true,
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build": true,
+		"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip": true
 	},
 	"Invocations": [
 		{
@@ -282,11 +282,11 @@
 				"python",
 				"-c",
 				"import os, sys; os.stat(sys.argv[1]); sys.stdout.write(os.path.realpath(sys.argv[1]))",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/versions/2.6.3"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/versions/2.6.3"
 			],
 			"Output": {
 				"Stdout": "",
-				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTAzMzI0NTY2MC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52L3ZlcnNpb25zLzIuNi4zJwo="
+				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTE2NTgxMjExMC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52L3ZlcnNpb25zLzIuNi4zJwo="
 			},
 			"Error": "local run: exit status 1"
 		},
@@ -295,11 +295,11 @@
 				"python",
 				"-c",
 				"import os, sys; os.stat(sys.argv[1]); sys.stdout.write(os.path.realpath(sys.argv[1]))",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 			],
 			"Output": {
 				"Stdout": "",
-				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTAzMzI0NTY2MC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52Jwo="
+				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTE2NTgxMjExMC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52Jwo="
 			},
 			"Error": "local run: exit status 1"
 		},
@@ -307,7 +307,7 @@
 			"Argv": [
 				"mkdir",
 				"-p",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 			],
 			"Output": {
 				"Stderr": ""
@@ -316,9 +316,9 @@
 		{
 			"Argv": [
 				"tee",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv.zip"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv.zip"
 			],
-			"StdinSHA256": "33f838ac3999a7078ca5709dee237afa7e3ec7c75dfdb92f2f0f54fe7fa8ecb1",
+			"StdinSHA256": "c52e72a4fb20efc520b6b3b9323dd7a559bdf2e682bd7f15dd99fa917b22d2b7",
 			"Output": {
 				"Stderr": ""
 			}
@@ -327,9 +327,9 @@
 			"Argv": [
 				"unzip",
 				"-q",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv.zip"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv.zip"
 			],
-			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv",
+			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv",
 			"Output": {
 				"Combined": ""
 			}
@@ -337,21 +337,21 @@
 		{
 			"Argv": [
 				"mv",
-				"rbenv-master/.github",
-				"rbenv-master/.gitignore",
-				"rbenv-master/.vimrc",
-				"rbenv-master/CODE_OF_CONDUCT.md",
-				"rbenv-master/LICENSE",
-				"rbenv-master/README.md",
-				"rbenv-master/bin",
-				"rbenv-master/completions",
-				"rbenv-master/libexec",
-				"rbenv-master/rbenv.d",
-				"rbenv-master/src",
-				"rbenv-master/test",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/.github",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/.gitignore",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/.vimrc",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/CODE_OF_CONDUCT.md",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/LICENSE",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/README.md",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/bin",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/completions",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/libexec",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/rbenv.d",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/src",
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3/test",
 				"."
 			],
-			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv",
+			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv",
 			"Output": {
 				"Combined": ""
 			}
@@ -359,9 +359,9 @@
 		{
 			"Argv": [
 				"rmdir",
-				"rbenv-master"
+				"rbenv-60c933968584ac9ae7caac6dbed614740f899ec3"
 			],
-			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv",
+			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv",
 			"Output": {
 				"Combined": ""
 			}
@@ -370,7 +370,7 @@
 			"Argv": [
 				"rm",
 				"-f",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv.zip"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv.zip"
 			],
 			"Output": {
 				"Combined": ""
@@ -381,11 +381,11 @@
 				"python",
 				"-c",
 				"import os, sys; os.stat(sys.argv[1]); sys.stdout.write(os.path.realpath(sys.argv[1]))",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build"
 			],
 			"Output": {
 				"Stdout": "",
-				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTAzMzI0NTY2MC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52L3BsdWdpbnMvcnVieS1idWlsZCcK"
+				"Stderr": "VHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIjxzdHJpbmc+IiwgbGluZSAxLCBpbiA8bW9kdWxlPgpPU0Vycm9yOiBbRXJybm8gMl0gTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeTogJy92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTE2NTgxMjExMC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52L3BsdWdpbnMvcnVieS1idWlsZCcK"
 			},
 			"Error": "local run: exit status 1"
 		},
@@ -393,7 +393,7 @@
 			"Argv": [
 				"mkdir",
 				"-p",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build"
 			],
 			"Output": {
 				"Stderr": ""
@@ -402,9 +402,9 @@
 		{
 			"Argv": [
 				"tee",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
 			],
-			"StdinSHA256": "164943fbc761f036ee97f41a7861d894306a23a73be81509de548259b612e240",
+			"StdinSHA256": "be9c01fb952ac76f3615d94ea74b39319b76a3203c1ff417cfed01818bbb7bbe",
 			"Output": {
 				"Stderr": ""
 			}
@@ -413,9 +413,9 @@
 			"Argv": [
 				"unzip",
 				"-q",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
 			],
-			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build",
+			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build",
 			"Output": {
 				"Combined": ""
 			}
@@ -423,20 +423,20 @@
 		{
 			"Argv": [
 				"mv",
-				"ruby-build-master/.github",
-				"ruby-build-master/.gitignore",
-				"ruby-build-master/.travis.yml",
-				"ruby-build-master/CODE_OF_CONDUCT.md",
-				"ruby-build-master/LICENSE",
-				"ruby-build-master/README.md",
-				"ruby-build-master/bin",
-				"ruby-build-master/install.sh",
-				"ruby-build-master/script",
-				"ruby-build-master/share",
-				"ruby-build-master/test",
+				"ruby-build-20201118/.github",
+				"ruby-build-20201118/.gitignore",
+				"ruby-build-20201118/.travis.yml",
+				"ruby-build-20201118/CODE_OF_CONDUCT.md",
+				"ruby-build-20201118/LICENSE",
+				"ruby-build-20201118/README.md",
+				"ruby-build-20201118/bin",
+				"ruby-build-20201118/install.sh",
+				"ruby-build-20201118/script",
+				"ruby-build-20201118/share",
+				"ruby-build-20201118/test",
 				"."
 			],
-			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build",
+			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build",
 			"Output": {
 				"Combined": ""
 			}
@@ -444,9 +444,9 @@
 		{
 			"Argv": [
 				"rmdir",
-				"ruby-build-master"
+				"ruby-build-20201118"
 			],
-			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build",
+			"Dir": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build",
 			"Output": {
 				"Combined": ""
 			}
@@ -455,7 +455,7 @@
 			"Argv": [
 				"rm",
 				"-f",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/plugins/ruby-build.zip"
 			],
 			"Output": {
 				"Combined": ""
@@ -468,13 +468,13 @@
 				"2.6.3"
 			],
 			"EnvVars": {
-				"RBENV_ROOT": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv"
+				"RBENV_ROOT": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv"
 			},
 			"PrependPath": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/bin"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/bin"
 			],
 			"Output": {
-				"Combined": "RG93bmxvYWRpbmcgb3BlbnNzbC0xLjEuMWgudGFyLmd6Li4uCi0+IGh0dHBzOi8vZHF3OG5tamNxcGpuNy5jbG91ZGZyb250Lm5ldC81YzljYTg3NzRiZDdiMDNlNTc4NGYyNmFlOWU5ZTZkNzQ5YzlkYTI0Mzg1NDUwNzdlNmIzZDc1NWEwNjU5NWQ5Ckluc3RhbGxpbmcgb3BlbnNzbC0xLjEuMWguLi4KSW5zdGFsbGVkIG9wZW5zc2wtMS4xLjFoIHRvIC92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTAzMzI0NTY2MC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52L3ZlcnNpb25zLzIuNi4zCgpEb3dubG9hZGluZyBydWJ5LTIuNi4zLnRhci5iejIuLi4KLT4gaHR0cHM6Ly9jYWNoZS5ydWJ5LWxhbmcub3JnL3B1Yi9ydWJ5LzIuNi9ydWJ5LTIuNi4zLnRhci5iejIKSW5zdGFsbGluZyBydWJ5LTIuNi4zLi4uCkluc3RhbGxlZCBydWJ5LTIuNi4zIHRvIC92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTAzMzI0NTY2MC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52L3ZlcnNpb25zLzIuNi4zCgo="
+				"Combined": "RG93bmxvYWRpbmcgb3BlbnNzbC0xLjEuMWgudGFyLmd6Li4uCi0+IGh0dHBzOi8vZHF3OG5tamNxcGpuNy5jbG91ZGZyb250Lm5ldC81YzljYTg3NzRiZDdiMDNlNTc4NGYyNmFlOWU5ZTZkNzQ5YzlkYTI0Mzg1NDUwNzdlNmIzZDc1NWEwNjU5NWQ5Ckluc3RhbGxpbmcgb3BlbnNzbC0xLjEuMWguLi4KSW5zdGFsbGVkIG9wZW5zc2wtMS4xLjFoIHRvIC92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTE2NTgxMjExMC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52L3ZlcnNpb25zLzIuNi4zCgpEb3dubG9hZGluZyBydWJ5LTIuNi4zLnRhci5iejIuLi4KLT4gaHR0cHM6Ly9jYWNoZS5ydWJ5LWxhbmcub3JnL3B1Yi9ydWJ5LzIuNi9ydWJ5LTIuNi4zLnRhci5iejIKSW5zdGFsbGluZyBydWJ5LTIuNi4zLi4uCkluc3RhbGxlZCBydWJ5LTIuNi4zIHRvIC92YXIvZm9sZGVycy9nbC84a3hjMXp4NTc0YjJ5Ymp0dnhoNDdqeTQwMDAwa2svVC9UZXN0UnVieTE2NTgxMjExMC8wMDIvLmNhY2hlL3liL3Rvb2xzL3JiZW52L3ZlcnNpb25zLzIuNi4zCgo="
 			}
 		},
 		{
@@ -483,11 +483,11 @@
 				"--version"
 			],
 			"EnvVars": {
-				"GEM_HOME": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/rubygems"
+				"GEM_HOME": "/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/rubygems"
 			},
 			"PrependPath": [
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/rubygems/bin",
-				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby033245660/002/.cache/yb/tools/rbenv/versions/2.6.3/bin"
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/rubygems/bin",
+				"/var/folders/gl/8kxc1zx574b2ybjtvxh47jy40000kk/T/TestRuby165812110/002/.cache/yb/tools/rbenv/versions/2.6.3/bin"
 			],
 			"Output": {
 				"Combined": "cnVieSAyLjYuM3A2MiAoMjAxOS0wNC0xNiByZXZpc2lvbiA2NzU4MCkgW3g4Nl82NC1kYXJ3aW4xOV0K"


### PR DESCRIPTION
This affects reproducibility, both for the user and our tests.

Fixes ch-3098