### PR TITLE
Allow underscores in Flutter pre-release version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 -  The Ruby buildpack downloads a pinned version of rbenv and ruby-build rather
    than following the latest commit.
+-  The Flutter buildpack now correctly handles the same pre-release version
+   formats as previous versions of yb.
 
 ## [0.5.2][] - 2020-11-18
 

--- a/internal/buildpack/flutter.go
+++ b/internal/buildpack/flutter.go
@@ -89,10 +89,10 @@ func flutterDownloadURL(version string, desc *biome.Descriptor) (string, error) 
 
 	data.Version = version
 	switch {
-	case strings.HasSuffix(version, "-beta"):
+	case strings.HasSuffix(version, "-beta") || strings.HasSuffix(version, "_beta"):
 		data.Version = data.Version[:len(data.Version)-len("-beta")]
 		data.Channel = "beta"
-	case strings.HasSuffix(version, "-dev"):
+	case strings.HasSuffix(version, "-dev") || strings.HasSuffix(version, "_dev"):
 		data.Version = data.Version[:len(data.Version)-len("-dev")]
 		data.Channel = "dev"
 	default:

--- a/internal/buildpack/flutter_test.go
+++ b/internal/buildpack/flutter_test.go
@@ -65,6 +65,11 @@ func TestFlutterDownloadURL(t *testing.T) {
 			os:      biome.Linux,
 			want:    "https://storage.googleapis.com/flutter_infra/releases/dev/linux/flutter_linux_1.17.0-dev.0.0-dev.tar.xz",
 		},
+		{
+			version: "1.23.0-18.1.pre_beta",
+			os:      biome.Linux,
+			want:    "https://storage.googleapis.com/flutter_infra/releases/beta/linux/flutter_linux_1.23.0-18.1.pre-beta.tar.xz",
+		},
 	}
 	for _, test := range tests {
 		desc := &biome.Descriptor{OS: test.os, Arch: biome.Intel64}


### PR DESCRIPTION
Fixes ch-3106