### PR TITLE
Don't drop YB_CONTAINER_*_IP values if there are no containers to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 -  `yb exec` installs the runtime dependencies in its environment. This was a
    regression from 0.4.
+-  Container IP addresses in the yb environment are respected in configuration
+   environment variable expansions. This was a regression from 0.4.
 -  The Ruby buildpack downloads a pinned version of rbenv and ruby-build rather
    than following the latest commit.
 -  The Flutter buildpack now correctly handles the same pre-release version

--- a/internal/build/setup.go
+++ b/internal/build/setup.go
@@ -142,7 +142,7 @@ func startContainers(ctx context.Context, sys Sys, defs map[string]*narwhal.Cont
 		}
 	}
 	if len(containers) == 0 {
-		return containersExpansion{}, func() error { return nil }, nil
+		return exp, func() error { return nil }, nil
 	}
 	if sys.DockerClient == nil {
 		names := make([]string, 0, len(containers))


### PR DESCRIPTION
QA'd by running our CI system locally against a target that has container dependencies.

Fixes ch-3105