### PR TITLE
Cancel command context on SIGINT/SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog][], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Unreleased]: https://github.com/yourbase/yb/compare/v0.5.4...HEAD
 
+## [Unreleased][]
+
+### Fixed
+
+-  Interrupting yb now cleans up any running processes or containers and reports
+   the error like other build failures.
+
 ## [0.5.4][] - 2020-11-30
 
 Version 0.5.4 fixes more regressions from 0.4.

--- a/cmd/yb/main.go
+++ b/cmd/yb/main.go
@@ -82,8 +82,11 @@ func main() {
 		},
 	})
 
-	ctx := context.Background()
-	if err := rootCmd.ExecuteContext(ctx); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	setupSignals(cancel)
+	err := rootCmd.ExecuteContext(ctx)
+	cancel()
+	if err != nil {
 		initLog(false)
 		log.Errorf(ctx, "%v", err)
 		os.Exit(1)

--- a/cmd/yb/signals_unix.go
+++ b/cmd/yb/signals_unix.go
@@ -1,0 +1,37 @@
+// Copyright 2020 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// +build !windows
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"golang.org/x/sys/unix"
+)
+
+func setupSignals(cancel context.CancelFunc) {
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, unix.SIGINT, unix.SIGTERM)
+	signal.Ignore(unix.SIGPIPE)
+	go func() {
+		<-interrupt
+		cancel()
+	}()
+}

--- a/cmd/yb/signals_windows.go
+++ b/cmd/yb/signals_windows.go
@@ -1,0 +1,32 @@
+// Copyright 2020 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+func setupSignals(cancel context.CancelFunc) {
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+	go func() {
+		<-interrupt
+		cancel()
+	}()
+}

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a
 	google.golang.org/genproto v0.0.0-20200831141814-d751682dd103 // indirect
 	google.golang.org/grpc v1.31.1 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect


### PR DESCRIPTION
The Docker biome reacts by restarting the container. This stops any currently running processes and then permits any final cleanup to run at the expense of any concurrent processes.

Included a small fix to ensure buildpack archive extraction cleanup does not receive an interrupt.

Fixes ch-2213