### PR TITLE
Use xcontext.KeepAlive instead of context.WithTimeout

### DIFF
--- a/internal/buildpack/buildpack.go
+++ b/internal/buildpack/buildpack.go
@@ -130,7 +130,7 @@ func extract(ctx context.Context, sys Sys, dstDir, url string, extractMode bool)
 	defer func() {
 		// Attempt to clean up if unarchive fails.
 		if err != nil {
-			ctx, cancel := context.WithTimeout(xcontext.IgnoreDeadline(ctx), cleanupTimeout)
+			ctx, cancel := xcontext.KeepAlive(ctx, cleanupTimeout)
 			defer cancel()
 			rmErr := sys.Biome.Run(ctx, &biome.Invocation{
 				Argv:   []string{"rm", "-rf", dstDir},
@@ -148,7 +148,7 @@ func extract(ctx context.Context, sys Sys, dstDir, url string, extractMode bool)
 	}
 	dstFile := dstDir + ext
 	defer func() {
-		ctx, cancel := context.WithTimeout(xcontext.IgnoreDeadline(ctx), cleanupTimeout)
+		ctx, cancel := xcontext.KeepAlive(ctx, cleanupTimeout)
 		defer cancel()
 		rmErr := sys.Biome.Run(ctx, &biome.Invocation{
 			Argv:   []string{"rm", "-f", dstFile},

--- a/internal/buildpack/rlang.go
+++ b/internal/buildpack/rlang.go
@@ -54,7 +54,7 @@ func installR(ctx context.Context, sys Sys, spec yb.BuildpackSpec) (_ biome.Envi
 		// Remove build directory on failure to prevent subsequent invocations from
 		// using a corrupt installation.
 		if err != nil {
-			rmCtx, cancel := context.WithTimeout(xcontext.IgnoreDeadline(ctx), 10*time.Second)
+			rmCtx, cancel := xcontext.KeepAlive(ctx, 10*time.Second)
 			defer cancel()
 			rmErr := sys.Biome.Run(rmCtx, &biome.Invocation{
 				Argv:   []string{"rm", "-rf", rlangDir},


### PR DESCRIPTION
Gives longer cleanup time to operations that failed for a reason unrelated to cancellation.