### PR TITLE
Update to Narwhal 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 -  Unknown keys in `.yourbase.yml` objects will now cause errors. Previously
    they were ignored.
+-  `yb checkconfig` will now display errors about invalid container mounts.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
 -  `github.com/yourbase/yb` is now a Go package for reading
    `.yourbase.yml` files. The API is mostly stable, but may still change before
    yb 1.0.
+-  Container mounts in `.yourbase.yml` can now refer to relative paths in the
+   package directory.
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/ulikunitz/xz v0.5.8
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yourbase/commons v0.8.0
-	github.com/yourbase/narwhal v0.8.0
+	github.com/yourbase/narwhal v0.9.0
 	go.opentelemetry.io/otel v0.11.0
 	go.opentelemetry.io/otel/sdk v0.11.0
 	go4.org v0.0.0-20200411211856-f5505b9728dd

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/ulikunitz/xz v0.5.8
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yourbase/commons v0.8.0
-	github.com/yourbase/narwhal v0.7.0
+	github.com/yourbase/narwhal v0.8.0
 	go.opentelemetry.io/otel v0.11.0
 	go.opentelemetry.io/otel/sdk v0.11.0
 	go4.org v0.0.0-20200411211856-f5505b9728dd

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMX
 github.com/containerd/containerd v1.3.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.0 h1:aWJB3lbDEaOxg1mkTBAINY2a+NsoKbAeRYefJPPRY+o=
 github.com/containerd/containerd v1.4.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc h1:TP+534wVlf61smEIq1nwLLAjQVEK2EADoW3CX9AuT+8=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 h1:NmTXa/uVnDyp0TY5MKi197+3HWcnYWfnHGyaFthlnGw=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -325,6 +326,7 @@ github.com/moby/term v0.0.0-20200915141129-7f0af18e79f2 h1:SPoLlS9qUUnXcIY4pvA4C
 github.com/moby/term v0.0.0-20200915141129-7f0af18e79f2/go.mod h1:TjQg8pa4iejrUrjiz0MCtMV38jdMNW4doKSiBrEvCQQ=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c h1:nXxl5PrvVm2L/wCy8dQu6DMTwH4oIuGN8GJDAlqDdVE=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
@@ -465,8 +467,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/yourbase/commons v0.1.0/go.mod h1:33VOfAZFfHwouAocNBqM9o5ZpCIwwSQq3vqjKpYK8sc=
 github.com/yourbase/commons v0.8.0 h1:Q7CPO9MicvxJVe6QEBVnYoSJwdvq+VfCqVuKIBiA7eE=
 github.com/yourbase/commons v0.8.0/go.mod h1:Puc7zTNtP4J7cRK9LkAUWYdORUQ0f7ZcgFFu2lxOe4Y=
-github.com/yourbase/narwhal v0.7.0 h1:WJZ0H5H6AhaPlgUaUVXqRfQrnW+VlqyC2vHxprWWEsM=
-github.com/yourbase/narwhal v0.7.0/go.mod h1:X1FC2daND8bK/vrhDsa00VtR4vnwYcmPUAzKF/FXdyw=
+github.com/yourbase/narwhal v0.8.0 h1:tR8FD51PLxWZuR5P+3r7Tjt1bQ19/Pi8Q+VlOcAbrcg=
+github.com/yourbase/narwhal v0.8.0/go.mod h1:X1FC2daND8bK/vrhDsa00VtR4vnwYcmPUAzKF/FXdyw=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/yourbase/commons v0.1.0/go.mod h1:33VOfAZFfHwouAocNBqM9o5ZpCIwwSQq3vqjKpYK8sc=
 github.com/yourbase/commons v0.8.0 h1:Q7CPO9MicvxJVe6QEBVnYoSJwdvq+VfCqVuKIBiA7eE=
 github.com/yourbase/commons v0.8.0/go.mod h1:Puc7zTNtP4J7cRK9LkAUWYdORUQ0f7ZcgFFu2lxOe4Y=
-github.com/yourbase/narwhal v0.8.0 h1:tR8FD51PLxWZuR5P+3r7Tjt1bQ19/Pi8Q+VlOcAbrcg=
-github.com/yourbase/narwhal v0.8.0/go.mod h1:X1FC2daND8bK/vrhDsa00VtR4vnwYcmPUAzKF/FXdyw=
+github.com/yourbase/narwhal v0.9.0 h1:AFeow0kTOUgNITLEOQu/Yw+ZkD7Dp4IUxtSczPMRWN8=
+github.com/yourbase/narwhal v0.9.0/go.mod h1:X1FC2daND8bK/vrhDsa00VtR4vnwYcmPUAzKF/FXdyw=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/internal/biome/docker.go
+++ b/internal/biome/docker.go
@@ -142,20 +142,20 @@ func CreateContainer(ctx context.Context, client *docker.Client, opts *Container
 		pullOutput = ioutil.Discard
 	}
 	log.Infof(ctx, "Creating %s container...", defn.Image)
-	container, err := narwhal.CreateContainer(ctx, client, pullOutput, defn)
+	containerID, err := narwhal.CreateContainer(ctx, client, pullOutput, defn)
 	if err != nil {
 		return nil, fmt.Errorf("create build container: %w", err)
 	}
-	span.SetAttribute("docker.container_id", container.ID)
+	span.SetAttribute("docker.container_id", containerID)
 	defer func() {
 		if err != nil {
 			rmErr := client.RemoveContainer(docker.RemoveContainerOptions{
 				Context: xcontext.IgnoreDeadline(ctx),
-				ID:      container.ID,
+				ID:      containerID,
 				Force:   true,
 			})
 			if rmErr != nil {
-				log.Warnf(ctx, "Cleaning up container %s: %v", container.ID, rmErr)
+				log.Warnf(ctx, "Cleaning up container %s: %v", containerID, rmErr)
 			}
 		}
 	}()
@@ -163,7 +163,7 @@ func CreateContainer(ctx context.Context, client *docker.Client, opts *Container
 	if opts.NetworkID != "" {
 		err := client.ConnectNetwork(opts.NetworkID, docker.NetworkConnectionOptions{
 			Context:   ctx,
-			Container: container.ID,
+			Container: containerID,
 			EndpointConfig: &docker.EndpointConfig{
 				NetworkID: opts.NetworkID,
 			},
@@ -172,18 +172,18 @@ func CreateContainer(ctx context.Context, client *docker.Client, opts *Container
 			return nil, fmt.Errorf("create build container: %w", err)
 		}
 	}
-	if err := uploadTini(ctx, client, container.ID, opts.TiniExe); err != nil {
+	if err := uploadTini(ctx, client, containerID, opts.TiniExe); err != nil {
 		return nil, fmt.Errorf("create build container: %w", err)
 	}
-	if err := narwhal.MkdirAll(ctx, client, container.ID, containerHome, nil); err != nil {
+	if err := narwhal.MkdirAll(ctx, client, containerID, containerHome, nil); err != nil {
 		return nil, fmt.Errorf("create build container: create home: %w", err)
 	}
-	if err := narwhal.StartContainer(ctx, client, container.ID); err != nil {
+	if err := narwhal.StartContainer(ctx, client, containerID, defn.HealthCheckPort); err != nil {
 		return nil, fmt.Errorf("create build container: %w", err)
 	}
 	return &Container{
 		client: client,
-		id:     container.ID,
+		id:     containerID,
 		dirs: Dirs{
 			Home:    containerHome,
 			Package: defn.WorkDir,

--- a/internal/biome/docker_test.go
+++ b/internal/biome/docker_test.go
@@ -73,8 +73,12 @@ func TestContainer(t *testing.T) {
 		TiniExe:    tiniResp.Body,
 		PullOutput: pullOutput,
 		Definition: &narwhal.ContainerDefinition{
-			Mounts: []string{
-				mountDir + ":/mymount",
+			Mounts: []docker.HostMount{
+				{
+					Source: mountDir,
+					Target: "/mymount",
+					Type:   BindMount,
+				},
 			},
 		},
 	})

--- a/internal/build/setup.go
+++ b/internal/build/setup.go
@@ -190,14 +190,14 @@ func startContainer(ctx context.Context, sys Sys, resourceName string, cd *yb.Re
 		}
 	}
 	log.Infof(ctx, "Starting container %s...", resourceName)
-	narwhalContainer, err := narwhal.CreateContainer(ctx, sys.DockerClient, sys.Stderr, &cd.ContainerDefinition)
+	containerID, err := narwhal.CreateContainer(ctx, sys.DockerClient, sys.Stderr, &cd.ContainerDefinition)
 	if err != nil {
 		return nil, fmt.Errorf("start resource %s: %w", resourceName, err)
 	}
 	c := &container{
 		client:       sys.DockerClient,
 		resourceName: resourceName,
-		id:           narwhalContainer.ID,
+		id:           containerID,
 	}
 	defer func() {
 		if err != nil {
@@ -214,24 +214,19 @@ func startContainer(ctx context.Context, sys Sys, resourceName string, cd *yb.Re
 	if err != nil {
 		return nil, fmt.Errorf("start resource %s: connect %s to %s: %w", resourceName, c.id, sys.DockerNetworkID, err)
 	}
-	if err := narwhal.StartContainer(ctx, sys.DockerClient, c.id); err != nil {
+	if cd.HealthCheckTimeout > 0 {
+		log.Infof(ctx, "Waiting up to %v for %s to be ready... ", cd.HealthCheckTimeout, resourceName)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cd.HealthCheckTimeout)
+		defer cancel()
+	}
+	if err := narwhal.StartContainer(ctx, sys.DockerClient, c.id, cd.HealthCheckPort); err != nil {
 		return nil, fmt.Errorf("start resource %s: %w", resourceName, err)
 	}
 	c.ip, err = narwhal.IPv4Address(ctx, sys.DockerClient, c.id)
 	if err != nil {
 		return nil, fmt.Errorf("start resource %s: %w", resourceName, err)
 	}
-
-	if narwhalContainer.HealthCheckAddr != nil {
-		// Wait for port to be reachable.
-		log.Infof(ctx, "Waiting up to %v for %s to be ready... ", cd.HealthCheckTimeout, resourceName)
-		ctx, cancel := context.WithTimeout(ctx, cd.HealthCheckTimeout)
-		defer cancel()
-		if err := waitForTCPPort(ctx, narwhalContainer.HealthCheckAddr.String()); err != nil {
-			return nil, fmt.Errorf("start resource %s: %w", resourceName, err)
-		}
-	}
-
 	return c, nil
 }
 
@@ -255,25 +250,6 @@ func (c *container) remove(ctx context.Context) {
 	if err != nil {
 		// These errors aren't actionable, so log them instead of returning them.
 		log.Warnf(ctx, "Leaked %s container %s: %v", c.resourceName, c.id, err)
-	}
-}
-
-func waitForTCPPort(ctx context.Context, addr string) error {
-	dialer := new(net.Dialer)
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		c, err := dialer.DialContext(ctx, "tcp", addr)
-		if err == nil {
-			c.Close()
-			return nil
-		}
-		select {
-		case <-ticker.C:
-		case <-ctx.Done():
-			return fmt.Errorf("wait for %q: %w", addr, err)
-		}
 	}
 }
 

--- a/package.go
+++ b/package.go
@@ -67,14 +67,11 @@ func LoadPackage(configPath string) (*Package, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load package %s: %w", configPath, err)
 	}
-	pkg, err := parse(configYAML)
+	pkg, err := parse(filepath.Dir(configPath), configYAML)
 	if err != nil {
 		return nil, fmt.Errorf("load package %s: %w", configPath, err)
 	}
 	// TODO(light): Validate the package for dependency cycles.
-	dir := filepath.Dir(configPath)
-	pkg.Name = filepath.Base(dir)
-	pkg.Path = dir
 	return pkg, nil
 }
 

--- a/parse.go
+++ b/parse.go
@@ -310,7 +310,7 @@ func (def *containerDefinition) toResource(packageDir string) (*ResourceDefiniti
 func parseHostMount(packageDir string, s string) (docker.HostMount, error) {
 	parts := strings.Split(s, ":")
 	if len(parts) != 2 {
-		return docker.HostMount{}, fmt.Errorf("parse mount %q: must contain exactly one ':'", parts)
+		return docker.HostMount{}, fmt.Errorf("parse mount %q: must contain exactly one ':'", s)
 	}
 	mount := docker.HostMount{
 		Source: filepath.FromSlash(parts[0]),

--- a/testdata/LoadPackage/Mounts.yml
+++ b/testdata/LoadPackage/Mounts.yml
@@ -1,0 +1,8 @@
+build_targets:
+  - name: default
+    container:
+      mounts:
+        - relative:/foo
+        - /absolute:/bar
+    commands:
+      - /bin/true


### PR DESCRIPTION
Narwhal 0.8 eliminates the string parsing of `ContainerDefinition.Mounts` and leaves it up to the caller to provide a more structured mount definition. This pushes two new responsibilities into yb: parsing mounts (including relative directories) and creating mount directories on the host as appropriate.

This means that mount parsing can now be tested like any other part of our YAML files and validated with `yb checkconfig`!

Updates ch-466
Updates #28