### PR TITLE
Generate shell completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
    in the directory.
 -  The new `yb clean` command deletes the cache for the package or specific
    targets.
+-  bash and zsh completion scripts are now included in our binary distributions.
+   These are automatically installed in Homebrew and the Debian packages.
 -  `github.com/yourbase/yb` is now a Go package for reading
    `.yourbase.yml` files. The API is mostly stable, but may still change before
    yb 1.0.

--- a/cmd/yb/build.go
+++ b/cmd/yb/build.go
@@ -55,6 +55,12 @@ func newBuildCmd() *cobra.Command {
 			}
 			return b.run(cmd.Context(), target)
 		},
+		ValidArgsFunction: func(cc *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return autocompleteTargetName(toComplete)
+		},
 	}
 	envFlagsVar(c.Flags(), &b.env)
 	netrcFlagVar(c.Flags(), &b.netrcFiles)

--- a/cmd/yb/clean.go
+++ b/cmd/yb/clean.go
@@ -46,6 +46,9 @@ func newCleanCmd() *cobra.Command {
 			return cmd.run(cc.Context())
 		},
 		DisableFlagsInUseLine: true,
+		ValidArgsFunction: func(cc *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return autocompleteTargetName(toComplete)
+		},
 	}
 	return c
 }

--- a/cmd/yb/gen_complete.go
+++ b/cmd/yb/gen_complete.go
@@ -1,0 +1,64 @@
+// Copyright 2020 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		 https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newGenCompleteCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:                   "gen-complete [flags] SHELL",
+		Short:                 "Generate shell completions (dev only)",
+		Args:                  cobra.ExactArgs(1),
+		Hidden:                true,
+		DisableFlagsInUseLine: true,
+	}
+	outputPath := c.Flags().StringP("output", "o", "-", "Output file ('-' for stdout)")
+	c.RunE = func(cc *cobra.Command, args []string) (err error) {
+		out := os.Stdout
+		if *outputPath != "-" {
+			f, err := os.Create(*outputPath)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if closeErr := f.Close(); err == nil && closeErr != nil {
+					err = closeErr
+				}
+			}()
+			out = f
+		}
+
+		switch args[0] {
+		case "bash":
+			return cc.Root().GenBashCompletion(out)
+		case "zsh":
+			return cc.Root().GenZshCompletion(out)
+		case "fish":
+			return cc.Root().GenFishCompletion(out, true)
+		case "powershell":
+			return cc.Root().GenPowerShellCompletion(out)
+		default:
+			return fmt.Errorf("unknown shell %q", args[0])
+		}
+	}
+	return c
+}

--- a/cmd/yb/helpers.go
+++ b/cmd/yb/helpers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/yourbase/narwhal"
 	"github.com/yourbase/yb"
@@ -200,4 +201,20 @@ func listTargetNames(targets map[string]*yb.Target) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// autocompleteTargetName provides tab completion suggestions for target names.
+func autocompleteTargetName(toComplete string) ([]string, cobra.ShellCompDirective) {
+	pkg, err := GetTargetPackage()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	names := make([]string, 0, len(pkg.Targets))
+	for k := range pkg.Targets {
+		if strings.HasPrefix(k, toComplete) {
+			names = append(names, k)
+		}
+	}
+	sort.Strings(names)
+	return names, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/yb/main.go
+++ b/cmd/yb/main.go
@@ -56,6 +56,7 @@ func main() {
 		newCleanCmd(),
 		newConfigCmd(),
 		newExecCmd(),
+		newGenCompleteCmd(),
 		newInitCmd(),
 		newLoginCmd(),
 		newRemoteCmd(),

--- a/cmd/yb/remote_build.go
+++ b/cmd/yb/remote_build.go
@@ -67,6 +67,12 @@ func newRemoteCmd() *cobra.Command {
 			}
 			return p.run(cmd.Context())
 		},
+		ValidArgsFunction: func(cc *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return autocompleteTargetName(toComplete)
+		},
 	}
 	c.Flags().StringVar(&p.baseCommit, "base-commit", "", "Base commit hash as common ancestor")
 	c.Flags().StringVar(&p.branch, "branch", "", "Branch name")

--- a/cmd/yb/run.go
+++ b/cmd/yb/run.go
@@ -38,6 +38,9 @@ func newRunCmd() *cobra.Command {
 	netrcFlagVar(c.Flags(), &b.netrcFiles)
 	c.Flags().StringVarP(&b.target, "target", "t", yb.DefaultTarget, "The target to run the command in")
 	c.Flags().BoolVar(&b.noContainer, "no-container", false, "Avoid using Docker if possible")
+	c.RegisterFlagCompletionFunc("target", func(cc *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return autocompleteTargetName(toComplete)
+	})
 	return c
 }
 

--- a/release/debpackage.sh
+++ b/release/debpackage.sh
@@ -61,13 +61,23 @@ mkdir -m 755 \
   "$stageroot/usr/bin" \
   "$stageroot/usr/share" \
   "$stageroot/usr/share/doc" \
-  "$stageroot/usr/share/doc/yb"
+  "$stageroot/usr/share/doc/yb" \
+  "$stageroot/usr/share/bash-completion" \
+  "$stageroot/usr/share/bash-completion/completions" \
+  "$stageroot/usr/share/zsh" \
+  "$stageroot/usr/share/zsh/zsh-completions"
 install -m 644 "$srcroot/debian/control" "$stageroot/DEBIAN/control"
 sed -i -e "s/^Version:.*/Version: $debversion/" "$stageroot/DEBIAN/control"
 sed -i -e "s/^Architecture: any\$/Architecture: $debarch/" "$stageroot/DEBIAN/control"
 install -m 644 "$srcroot/debian/copyright" "$stageroot/usr/share/doc/yb/copyright"
 "$srcroot/release/build.sh" "$stageroot/usr/bin/yb"
 chmod 755 "$stageroot/usr/bin/yb"
+# Generate and stage shell completions.
+"$stageroot/usr/bin/yb" gen-complete -o "$stageroot/usr/share/bash-completion/completions/yb" bash
+"$stageroot/usr/bin/yb" gen-complete -o "$stageroot/usr/share/zsh/zsh-completions/_yb" zsh
+chmod 644 \
+  "$stageroot/usr/share/bash-completion/completions/yb" \
+  "$stageroot/usr/share/zsh/zsh-completions/_yb"
 
 mkdir -m 755 \
   "$stageroot/usr/share/lintian" \

--- a/release/package.sh
+++ b/release/package.sh
@@ -69,6 +69,8 @@ mkzip "yb_${triple}_cats.zip"
 
 # Next: create end-user-friendly distribution.
 cp "$srcroot/README.md" "$srcroot/LICENSE" "$srcroot/CHANGELOG.md" "$distroot/"
+"$distroot/yb" gen-complete -o "$distroot/yb_complete.bash" bash
+"$distroot/yb" gen-complete -o "$distroot/yb_complete.zsh" zsh
 mkzip "yb_${triple}.zip"
 
 # Output triple.


### PR DESCRIPTION
Adds a hidden `gen-complete` subcommand in yb that generates the shell completions. See [Cobra docs](https://github.com/spf13/cobra/blob/master/shell_completions.md) for more details.

Fixes ch-731