### PR TITLE
Add new default "prefer host" mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,27 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 ### Added
 
+-  A new `--mode` option for `build`, `exec`, and `run` allows specifying
+   whether commands should be run inside or outside Docker.
 -  yb now obeys the `DOCKER_HOST` environment variable.
+
+### Changed
+
+-  Commands run as part of `build`, `exec`, or `run` now run without Docker by
+   default. You can get the old behavior by running with `--mode=container`.
 
 ### Fixed
 
 -  `yb init` no longer crashes when not given a `--lang` flag if there was
    a problem connecting to the Docker daemon.
+
+### Deprecated
+
+-  The `host_only` property in `.yourbase.yml` is now ignored. It may be removed
+   in a future version.
+-  The `--no-container` option in `build` and `run` is now equivalent to
+   `--mode=no-container`. It is still recognized, but no longer shown in
+   documentation and may be removed in a future version.
 
 ## [0.6.3][] - 2021-03-08
 
@@ -78,6 +93,8 @@ Version 0.5.7 backports a fix for a locale environment variable issue.
 
 -  The `TZ` environment variable is now set to `UTC0` by default. Previously,
    it was set to `UTC`, which is not a POSIX-conforming value.
+
+## [Unreleased][]
 
 ## [0.6.1][] - 2021-02-11
 

--- a/cmd/yb/init.go
+++ b/cmd/yb/init.go
@@ -82,7 +82,7 @@ func (cmd *initCmd) run(ctx context.Context) (cmdErr error) {
 	}
 
 	// Do a quick check to see if Docker works.
-	client, err := connectDockerClient(true)
+	client, err := connectDockerClient(useContainer)
 	if err != nil {
 		return err
 	}

--- a/package.go
+++ b/package.go
@@ -82,13 +82,18 @@ type Target struct {
 	Deps    map[*Target]struct{}
 	Tags    map[string]string
 
+	// Container specifies the container environment that should be used to run
+	// the commands in if container execution is requested. It will never be nil.
+	Container *narwhal.ContainerDefinition
+	// UseContainer indicates whether this target requires executing the commands
+	// inside a container.
+	UseContainer bool
+
 	Commands   []string
 	RunDir     string
-	Container  *narwhal.ContainerDefinition
 	Env        map[string]EnvTemplate
 	Buildpacks map[string]BuildpackSpec
 	Resources  map[string]*ResourceDefinition
-	HostOnly   bool
 }
 
 type ResourceDefinition struct {

--- a/parse.go
+++ b/parse.go
@@ -137,15 +137,15 @@ func parseTarget(packageDir string, globalDeps map[string]BuildpackSpec, tgt *bu
 		return nil, fmt.Errorf("target %s: dependencies: containers: %w", tgt.Name, err)
 	}
 	parsed := &Target{
-		Name:       tgt.Name,
-		Container:  &container.ContainerDefinition,
-		Commands:   tgt.Commands,
-		RunDir:     tgt.Root,
-		Tags:       tgt.Tags,
-		Env:        make(map[string]EnvTemplate),
-		Buildpacks: make(map[string]BuildpackSpec),
-		HostOnly:   tgt.HostOnly,
-		Resources:  resources,
+		Name:         tgt.Name,
+		Container:    &container.ContainerDefinition,
+		UseContainer: tgt.Container != nil,
+		Commands:     tgt.Commands,
+		RunDir:       tgt.Root,
+		Tags:         tgt.Tags,
+		Env:          make(map[string]EnvTemplate),
+		Buildpacks:   make(map[string]BuildpackSpec),
+		Resources:    resources,
 	}
 	for tool, spec := range globalDeps {
 		parsed.Buildpacks[tool] = spec
@@ -222,14 +222,14 @@ func parseExecPhase(pkg *Package, manifest *buildManifest) (map[string]*Target, 
 		return nil, fmt.Errorf("exec dependencies: %w", err)
 	}
 	defaultTarget := &Target{
-		Name:       DefaultExecEnvironment,
-		Package:    pkg,
-		Container:  &container.ContainerDefinition,
-		Commands:   manifest.Exec.Commands,
-		Env:        make(map[string]EnvTemplate),
-		Buildpacks: buildpacks,
-		HostOnly:   manifest.Exec.HostOnly,
-		Resources:  resources,
+		Name:         DefaultExecEnvironment,
+		Package:      pkg,
+		Container:    &container.ContainerDefinition,
+		UseContainer: manifest.Exec.Container != nil,
+		Commands:     manifest.Exec.Commands,
+		Env:          make(map[string]EnvTemplate),
+		Buildpacks:   buildpacks,
+		Resources:    resources,
 	}
 	if err := parseEnv(defaultTarget.Env, manifest.Exec.Environment[defaultTarget.Name]); err != nil {
 		return nil, fmt.Errorf("exec environment: %s: %w", defaultTarget.Name, err)

--- a/parse_test.go
+++ b/parse_test.go
@@ -149,6 +149,7 @@ func TestLoadPackage(t *testing.T) {
 								},
 							},
 						},
+						UseContainer: true,
 						Commands: []string{
 							"/bin/true",
 						},
@@ -169,6 +170,7 @@ func TestLoadPackage(t *testing.T) {
 								"5001",
 							},
 						},
+						UseContainer: true,
 						Buildpacks: map[string]BuildpackSpec{
 							"python": "python:3.7.7",
 						},
@@ -195,6 +197,7 @@ func TestLoadPackage(t *testing.T) {
 								"5001",
 							},
 						},
+						UseContainer: true,
 						Buildpacks: map[string]BuildpackSpec{
 							"python": "python:3.7.7",
 						},


### PR DESCRIPTION
Runs targets on the host, but spins up resource containers if the target requires them. Added a new `--mode` option to handle the three states. If a target specifies container information, then it will be run inside a Docker container.

Fixes ch-3867