### PR TITLE
Rename biome keychain to login instead of yb

### DIFF
--- a/cmd/yb/keychain.go
+++ b/cmd/yb/keychain.go
@@ -78,7 +78,7 @@ func ensureKeychain(ctx context.Context, bio biome.Biome) error {
 	keychainList := parseKeychainOutput(stdout.String())
 
 	// Create a passwordless keychain.
-	const keychainName = "yb.keychain"
+	const keychainName = "login.keychain"
 	if err := runCommand(ctx, bio, "security", "create-keychain", "-p", "", keychainName); err != nil {
 		return fmt.Errorf("ensure build environment keychain: %w", err)
 	}

--- a/cmd/yb/keychain_test.go
+++ b/cmd/yb/keychain_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -72,8 +73,13 @@ func TestEnsureKeychain(t *testing.T) {
 	if err != nil {
 		t.Error("security default-keychain:", err)
 	}
-	if len(parseKeychainOutput(stdout.String())) == 0 {
+	if keychains := parseKeychainOutput(stdout.String()); len(keychains) == 0 {
 		t.Error("No default keychain set")
+	} else if got, want := keychains[0], "login.keychain-db"; filepath.Base(got) != want {
+		// Many tools depend on the default keychain name being "login", so turn the
+		// implicit interface into an explicit test.
+		// See https://app.clubhouse.io/yourbaseio/story/4145 for more details.
+		t.Errorf("default keychain = %q; want name to be %q", got, want)
 	}
 
 	// Verify that running multiple times does not return an error and does not


### PR DESCRIPTION
There are many tools that seem to hardcode `login` as the name of the default keychain, and it would be better to have a default that is compatible rather than try to be different for the sake of shaking out code relying on implicit interfaces.

Updates ch-4145