### PR TITLE
Port content from docs.yourbase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ yb run --target=foo bash
 
 ## Documentation
 
-More documentation available at http://docs.yourbase.io
+More documentation available in the [docs folder](docs).
 
 ## Contributing 
 

--- a/docs/buildpacks.md
+++ b/docs/buildpacks.md
@@ -1,0 +1,47 @@
+# List of Build Packs
+
+| Build Pack   | Description                                | Example            |
+| ------------ | ------------------------------------------ | ------------------ |
+| `anaconda2`  | Python 2 via [Miniconda][]                 | `anaconda2:2.7.11` |
+| `anaconda3`  | Python 3 via [Miniconda][]                 | `anaconda3:3.9.2`  |
+| `android`    | [Android SDK][]                            | `android:latest` or a specific version like `android:4333796` |
+| `androidndk` | [Android NDK][]                            | `androidndk:r21e`  |
+| `ant`        | [Apache Ant][]                             | `ant:1.10.9` \*    |
+| `dart`       | [Dart SDK][]                               | `dart:2.12.2`      |
+| `flutter`    | [Flutter SDK][]                            | `flutter:2.0.3`    |
+| `glide`      | [Glide][] dependency manager for Go        | `glide:0.13.3`     |
+| `go`         | [Go][]                                     | `go:1.16.2`        |
+| `gradle`     | [Gradle][]                                 | `gradle:6.8.3` \*  |
+| `heroku`     | The [Heroku CLI][]                         | Only `heroku:latest` is allowed |
+| `java`       | [OpenJDK][] binaries from [AdoptOpenJDK][] | `java:16+36`       |
+| `maven`      | [Apache Maven][]                           | `maven:3.6.3` \*   |
+| `node`       | [Node.js][] with bundled npm               | `node:14.16.0`     |
+| `protoc`     | [Protocol Buffer compiler][]               | `protoc:3.15.6`    |
+| `python`     | Python via [Miniconda][]                   | `python:3.9.2` or `python:2.7.11` |
+| `r`          | [R][] programming language                 | `r:4.0.3`          |
+| `ruby`       | [Ruby][]                                   | `ruby:2.6.3`       |
+| `rust`       | [Rust][]                                   | `rust:1.51.0`      |
+| `yarn`       | [Yarn][] package manager for JavaScript    | `yarn:1.22.10`     |
+
+\* When using the `ant`, `gradle`, or `maven` build packs, you must also specify
+the `java` build pack.
+
+[AdoptOpenJDK]: https://adoptopenjdk.net/
+[Android NDK]: https://developer.android.com/ndk/downloads
+[Android SDK]: https://developer.android.com/studio/releases/sdk-tools
+[Apache Ant]: https://ant.apache.org/
+[Apache Maven]: https://maven.apache.org/download.cgi
+[Dart SDK]: https://dart.dev/get-dart
+[Flutter SDK]: https://flutter.dev/docs/get-started/install
+[Glide]: https://github.com/Masterminds/glide
+[Go]: https://golang.org/dl/
+[Gradle]: https://gradle.org/install/
+[Heroku CLI]: https://devcenter.heroku.com/articles/heroku-cli
+[Miniconda]: https://docs.conda.io/en/latest/miniconda.html
+[Node.js]: https://nodejs.org/
+[OpenJDK]: https://openjdk.java.net/
+[Protocol Buffer compiler]: https://github.com/protocolbuffers/protobuf/releases
+[R]: https://www.r-project.org/
+[Ruby]: https://www.ruby-lang.org/en/downloads/
+[Rust]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
+[Yarn]: https://github.com/yarnpkg/yarn/releases

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,211 @@
+# Package Configuration Reference
+
+The .yourbase.yml file is broken into four primary sections:
+
+-  Dependencies
+-  Build Targets
+-  Runtime Target
+-  CI Instructions
+
+## Dependencies
+
+The `dependencies` section describes what build packs need to be loaded for
+the build.
+
+Example:
+
+```yaml
+dependencies:
+  build:
+    - python:3.6.3
+  runtime:
+    - heroku:latest
+```
+
+-  `build`: Dependencies used by all `build_targets` (see below).
+-  `runtime`: Dependencies used by all `exec` environments (see below).
+
+## Build Targets
+
+The `build_targets` section is a list of build targets, each with a unique name
+a sequence of commands.
+
+Example:
+
+```yaml
+build_targets:
+  - name: build_and_deploy
+    commands:
+      - rake test
+      - rake package
+      - rake deploy
+```
+
+### Attributes
+
+-  `name`: The name of the build target. This is referenced on the
+   command-line `yb build targetname`, in CI configuration sections or as things
+   to build first.
+
+-  `commands`: The commands to be executed; these can be anything you would run
+   on the command-line. **Note** YourBase does not expand environment variables
+   using the normal `${VALUE}` syntax, though there are ways to do this.
+   We do not run `sh` or `bash` as this is not portable; if you need to do that,
+   create a shell script and run it as a command explicitly.
+
+-  `tags`: Tags are used to select which build server can handle each build.
+
+   -  `os`: Specifies which operating system this build target is applicable to.
+      Current valid options: `linux` (default) and `osx`.
+
+      ```yaml
+      - name: android
+        tags:
+          os: linux
+        commands:
+          - apt-get update
+          - apt-get install -y software-properties-common
+          - add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          - apt-get update
+          - apt-get install -y lib32stdc++6
+          - sh build.sh
+      - name: ios
+        tags:
+          os: darwin
+        commands:
+            - brew update
+            - brew install --HEAD usbmuxd
+            - brew link usbmuxd
+            - brew install --HEAD libimobiledevice
+            - brew install ideviceinstaller
+            - brew install ios-deploy
+            - sh build.sh
+      ```
+
+-  `environment`: A list of `KEY=VALUE` items that are used as environment
+   variables.
+
+   ```yaml
+   build_targets:
+     - name: default
+       environment:
+         - ENVIRONMENT=development
+         - DATABASE_URL=db://localhost:1234/foo
+   ```
+
+-  `root`: The name of a path where it should run commands from, relative to the
+   root of the project.
+
+-  `build_after`: A list of build targets whose commands will be executed before
+   this target.
+
+   ```yaml
+   build_targets:
+     - name: test
+       commands:
+         - python tests.py
+     - name: release
+       build_after:
+         - test
+       commands:
+         - python kraken.py
+   ```
+
+-  `container`: If this build is to be built in a container, this directive
+   allows you to describe the container. All the commands in the `commands`
+   directive will be executed inside a container using the provided
+   configuration.
+
+   ```yaml
+   build_targets:
+     - name: container_build
+       container:
+         image: golang:1.12
+         mounts:
+            - data:/data
+         ports:
+            - 123:456
+         environment:
+            - FOO=bar
+            - PASSWORD=sekret
+         workdir:
+            - /source
+       commands:
+         - go get
+         - go build
+         - go test ./...
+   ```
+
+## CI Build Directives
+
+The CI section allows you to define what to build and when by using a
+combination of build targets and conditions. In order for the CI system to
+properly build your project, you must define the `dependencies`, `build_targets`
+and `ci` sections.
+
+Simple example:
+
+```yaml
+dependencies:
+  build:
+    - python:3.6.3
+
+build_targets:
+  - name: default
+    commands:
+      - python test.py
+
+ci:
+  builds:
+    - name: all_commits
+      build_target: default
+```
+
+Each list item in builds has the following attributes:
+
+-  `name`: The name of the CI build itself (arbitrary string)
+-  `build_target`: The name of the build target to run. Must match one of the
+   names in the `build_targets` section.
+-  `when`: (Optional) CI build conditions for this target. You can use the
+   following variables and combine them using simple boolean logic using
+   [PyPred syntax][]:
+   -  `branch`: The name of the branch being built (e.g. `main`).
+   -  `action`: Either `commit` or `pull_request`
+   -  `tagged`: Boolean value, either `true` or `false`
+
+Example of CI builds with conditions:
+
+```yaml
+dependencies:
+  build:
+    - python:3.6.3
+
+build_targets:
+  - name: integration_tests
+    commands:
+      - python integration_test.py
+
+  - name: default
+    commands:
+      - python test.py
+
+  - name: release
+    commands:
+      - python release.py
+
+ci:
+  builds:
+    - name: main_builds
+      build_target: integration_tests
+      when: branch is 'main'
+
+    - name: pr_builds
+      build_target: default
+      when: action is 'pull_request'
+
+    - name: tags
+      build_target: release
+      when: tagged
+```
+
+[pypred syntax]: https://github.com/armon/pypred

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -1,0 +1,120 @@
+# Design Philosophy
+
+The YourBase ecosystem is designed around two primary goals:
+
+-  We should adhere to the principle of least surprise
+-  Our tools should provide consistent behavior and structure without forcing the user to go to extreme measures
+
+By design, integrating the yb tooling into your project should require
+minimal adaptation on the part of a team. We want to provide you with the
+structure to adapt your process over time while getting immediate value for
+minimal effort.
+
+What this means is that you do not need to re-write your entire build process
+to work with our tooling. If you use NPM and NodeJS, you should (and are)
+able to simply add to your .yourbase.yml file a few commands and be up and
+running. Once you see the value that the tool brings you can begin to adopt
+(or build) buildpacks in order to encourage better repeatability across
+systems.
+
+## Core Concepts
+
+YourBase is both a command-line tool and a build service. The primary goal of
+the tooling is to provide developers with a consistent experience throughout
+the development and release cycle. By eliminating the differences between how
+software is built locally as compared to how it is built by the build
+service, we remove the hassle of having to manage separate, infrequently
+used, configuration that describes traditional CI processes.
+
+There are a few primary building blocks used by YourBase:
+
+-  Dependencies
+-  Build targets
+-  Build service
+
+### Dependencies
+
+One of the major design goals of YB, as a tool, is to eliminate the need to
+manage tooling and dependencies for every language and separately from your
+build process. This is achieved by modeling the various languages and build
+systems one might use, such as Go, Node.JS, or Ruby as what we refer to as
+“build-packs”; by providing building blocks that can be combined to compose
+your projects tools, YB helps developers to be more productive by worrying
+less about installing and configuring tools required to work on a project.
+
+#### Build packs
+
+Build packs are programmatically described ways of installing, configuring,
+and setting up dependencies that your project has. Each build pack is
+responsible for managing the lifecycle of a single tool and can be combined
+with others to provide a rich multi-tool environment on a per-project basis.
+This has a number of design principles:
+
+-  Containment
+-  Composability
+-  Convenience
+-  Consistency
+-  Correctness
+
+#### Containment
+
+Each build pack is designed to contain its installation to its own versioned
+space that is commonly accessible to all projects while isolating its
+per-workspace resources in such a way that they do not impact the
+installation nor other workspaces that are using hat tool. For those familiar
+with Python’s virtual environments this may feel somewhat familiar.
+
+#### Composability
+
+Build packs should be able to be combined with one another to provide a
+multi-tool / language environment. For example, there are build packs for
+Maven, Gradle, the OpenJDK and the Oracle JDK. One should be able to leverage
+build packs for Maven and the Oracle JDK but then replace the Oracle
+dependency with the OpenJDK simply by changing the dependency list.
+
+#### Convenience
+
+One of the primary challenges we face with a wide variety of build tools is
+the effort involved in finding, installing, and configuring each tool. Tools
+have a variety of required environment variables, cache locations, download
+locations, and so on. Build packs take care of all of this so that in order
+to start using NodeJS 10.15, for example, a developer only needs to add the
+dependency and it will be fetched, configured and ready to use immediately.
+
+In addition to making it much simpler to begin using a new tool or language,
+it means that the on-boarding process for new developers is greatly
+simplified.
+
+#### Consistency
+
+By isolating each tool and working in a containers, per-project work area,
+there is a consistent experience for all developers working across a variety
+of projects. Each build pack understands platform-specific nuances and
+mediates them. And, because the YourBase Build Service uses the exact same
+CLI, all of the setup and configuration done during CI is exactly the same as
+locally.
+
+#### Correctness
+
+Because each build pack is written in Go, maintainers are able to write tests
+and verify that they work across a variety of platforms and environments.
+
+### Build targets
+
+Beyond the management of dependencies, YB manages build targets. Similar to
+what one might expect from Make or other tools, each build target is a set of
+steps required to build some result.
+
+Build targets provide the primary building block for local and CI system
+operations. In addition to commands to run, build targets can describe other
+dependencies, such as containers to run during the build process, environment
+variables, or dependencies on other targets being run first.
+
+### Build service
+
+The YB tool describes and manages build and testing in a way that is
+different from other tools. The build description is only composed of three
+pieces of information: the name of the build, the build target to execute,
+and when the build service should build that target. In doing so, YB runs
+builds in the exact same way they would be run locally. No more wondering if
+it will pass in the “CI” system if it builds correctly locally.


### PR DESCRIPTION
Most of the content is copied verbatim, with some light reformatting for GitHub-Flavored Markdown. However, the List of Build Packs was re-authored with the most up-to-date information and now includes examples of accepted versions.

I omitted "Getting Started with YourBase" and "How to Write Build Targets" because they are redundant with the content in README.md. The "Remote Building" page is better served by `yb remotebuild --help` instead of having a separate page we have to update.

Fixes ch-4338