### PR TITLE
Move host information into `yb version` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 -  Commands run as part of `build`, `exec`, or `run` now run without Docker by
    default. You can get the old behavior by running with `--mode=container`.
+-  `yb platform` is now an alias for `yb version`.
 
 ### Fixed
 

--- a/cmd/yb/build.go
+++ b/cmd/yb/build.go
@@ -10,7 +10,6 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/google/shlex"
-	"github.com/matishsiao/goInfo"
 	"github.com/spf13/cobra"
 	"github.com/yourbase/yb"
 	"github.com/yourbase/yb/internal/biome"
@@ -101,15 +100,6 @@ func (b *buildCmd) run(ctx context.Context, buildTargetName string) error {
 	ctx, span := ybtrace.Start(ctx, "Build", trace.WithNewRoot())
 	defer span.End()
 
-	if insideTheMatrix() {
-		startSection("BUILD")
-	} else {
-		startSection("BUILD HOST")
-	}
-	gi := goInfo.GetInfo()
-	gi.VarDump()
-
-	startSection("BUILD PACKAGE SETUP")
 	log.Infof(ctx, "Build started at %s", startTime.Format(longTimeFormat))
 
 	targetPackage, _, err := findPackage()

--- a/cmd/yb/main.go
+++ b/cmd/yb/main.go
@@ -5,13 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/matishsiao/goInfo"
 	"github.com/spf13/cobra"
-	"github.com/yourbase/commons/envvar"
 	"github.com/yourbase/yb/internal/config"
 	"zombiezen.com/go/log"
 )
@@ -112,99 +109,4 @@ func displayOldDirectoryWarning(ctx context.Context) {
 	if _, err := os.Stat(dir); err == nil {
 		log.Warnf(ctx, "yb no longer uses %s to store files. You can remove this directory to save disk space.", dir)
 	}
-}
-
-type logger struct {
-	color      bool
-	showLevels bool
-
-	mu  sync.Mutex
-	buf []byte
-}
-
-var logInitOnce sync.Once
-
-func initLog(cfg config.Getter, showDebug bool) {
-	logInitOnce.Do(func() {
-		log.SetDefault(&log.LevelFilter{
-			Min: configuredLogLevel(cfg, showDebug),
-			Output: &logger{
-				color:      colorLogs(),
-				showLevels: showLogLevels(cfg),
-			},
-		})
-	})
-}
-
-func (l *logger) Log(ctx context.Context, entry log.Entry) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	l.buf = l.buf[:0]
-	if l.showLevels {
-		if l.color {
-			switch {
-			case entry.Level >= log.Error:
-				// Red text
-				l.buf = append(l.buf, "\x1b[31m"...)
-			case entry.Level >= log.Warn:
-				// Yellow text
-				l.buf = append(l.buf, "\x1b[33m"...)
-			default:
-				// Cyan text
-				l.buf = append(l.buf, "\x1b[36m"...)
-			}
-		}
-		switch {
-		case entry.Level >= log.Error:
-			l.buf = append(l.buf, "ERROR"...)
-		case entry.Level >= log.Warn:
-			l.buf = append(l.buf, "WARN"...)
-		case entry.Level >= log.Info:
-			l.buf = append(l.buf, "INFO"...)
-		default:
-			l.buf = append(l.buf, "DEBUG"...)
-		}
-		if l.color {
-			l.buf = append(l.buf, "\x1b[0m"...)
-		}
-		l.buf = append(l.buf, ' ')
-	}
-	l.buf = append(l.buf, entry.Msg...)
-	l.buf = append(l.buf, '\n')
-	os.Stderr.Write(l.buf)
-}
-
-func (l *logger) LogEnabled(entry log.Entry) bool {
-	return true
-}
-
-func configuredLogLevel(cfg config.Getter, showDebug bool) log.Level {
-	if showDebug {
-		return log.Debug
-	}
-	l := config.Get(cfg, "defaults", "log-level")
-	switch strings.ToLower(l) {
-	case "debug":
-		return log.Debug
-	case "warn", "warning":
-		return log.Warn
-	case "error":
-		return log.Error
-	}
-	return log.Info
-}
-
-func colorLogs() bool {
-	b, _ := strconv.ParseBool(envvar.Get("CLICOLOR", "1"))
-	return b
-}
-
-func showLogLevels(cfg config.Getter) bool {
-	out := config.Get(cfg, "defaults", "no-pretty-output")
-	if out != "" {
-		b, _ := strconv.ParseBool(out)
-		return !b
-	}
-	return !envvar.Bool("YB_NO_PRETTY_OUTPUT")
 }

--- a/cmd/yb/main.go
+++ b/cmd/yb/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/matishsiao/goInfo"
@@ -21,9 +22,11 @@ var (
 )
 
 func versionString() string {
+	gi := goInfo.GetInfo()
 	sb := new(strings.Builder)
 	fmt.Fprintln(sb, version)
 	fmt.Fprintln(sb, "Channel:", channel)
+	fmt.Fprintf(sb, "Host OS: %s/%s %s (%d cores)\n", runtime.GOOS, runtime.GOARCH, gi.Core, runtime.NumCPU())
 	if date != "" {
 		fmt.Fprintln(sb, "Date:", date)
 	}
@@ -70,19 +73,9 @@ func main() {
 		newTokenCmd(cfg),
 	)
 	rootCmd.AddCommand(&cobra.Command{
-		Use:           "platform",
-		Short:         "Show platform information",
-		SilenceErrors: true,
-		SilenceUsage:  true,
-		Args:          cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			gi := goInfo.GetInfo()
-			gi.VarDump()
-		},
-	})
-	rootCmd.AddCommand(&cobra.Command{
 		Use:           "version",
-		Short:         "Show version info",
+		Short:         "Show version information",
+		Aliases:       []string{"platform"},
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Args:          cobra.NoArgs,

--- a/cmd/yb/output.go
+++ b/cmd/yb/output.go
@@ -1,0 +1,206 @@
+// Copyright 2021 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		 https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/yourbase/commons/envvar"
+	"github.com/yourbase/yb/internal/config"
+	"go.opentelemetry.io/otel/api/trace"
+	exporttrace "go.opentelemetry.io/otel/sdk/export/trace"
+	"zombiezen.com/go/log"
+)
+
+const longTimeFormat = "15:04:05 MST"
+
+type logger struct {
+	color      bool
+	showLevels bool
+
+	mu  sync.Mutex
+	buf []byte
+}
+
+var logInitOnce sync.Once
+
+func initLog(cfg config.Getter, showDebug bool) {
+	logInitOnce.Do(func() {
+		log.SetDefault(&log.LevelFilter{
+			Min: configuredLogLevel(cfg, showDebug),
+			Output: &logger{
+				color:      colorLogs(),
+				showLevels: showLogLevels(cfg),
+			},
+		})
+	})
+}
+
+func (l *logger) Log(ctx context.Context, entry log.Entry) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.buf = l.buf[:0]
+	if l.showLevels {
+		if l.color {
+			switch {
+			case entry.Level >= log.Error:
+				// Red text
+				l.buf = append(l.buf, "\x1b[31m"...)
+			case entry.Level >= log.Warn:
+				// Yellow text
+				l.buf = append(l.buf, "\x1b[33m"...)
+			default:
+				// Cyan text
+				l.buf = append(l.buf, "\x1b[36m"...)
+			}
+		}
+		switch {
+		case entry.Level >= log.Error:
+			l.buf = append(l.buf, "ERROR"...)
+		case entry.Level >= log.Warn:
+			l.buf = append(l.buf, "WARN"...)
+		case entry.Level >= log.Info:
+			l.buf = append(l.buf, "INFO"...)
+		default:
+			l.buf = append(l.buf, "DEBUG"...)
+		}
+		if l.color {
+			l.buf = append(l.buf, "\x1b[0m"...)
+		}
+		l.buf = append(l.buf, ' ')
+	}
+	l.buf = append(l.buf, entry.Msg...)
+	l.buf = append(l.buf, '\n')
+	os.Stderr.Write(l.buf)
+}
+
+func (l *logger) LogEnabled(entry log.Entry) bool {
+	return true
+}
+
+func configuredLogLevel(cfg config.Getter, showDebug bool) log.Level {
+	if showDebug {
+		return log.Debug
+	}
+	l := config.Get(cfg, "defaults", "log-level")
+	switch strings.ToLower(l) {
+	case "debug":
+		return log.Debug
+	case "warn", "warning":
+		return log.Warn
+	case "error":
+		return log.Error
+	}
+	return log.Info
+}
+
+func colorLogs() bool {
+	b, _ := strconv.ParseBool(envvar.Get("CLICOLOR", "1"))
+	return b
+}
+
+func showLogLevels(cfg config.Getter) bool {
+	out := config.Get(cfg, "defaults", "no-pretty-output")
+	if out != "" {
+		b, _ := strconv.ParseBool(out)
+		return !b
+	}
+	return !envvar.Bool("YB_NO_PRETTY_OUTPUT")
+}
+
+// A traceSink records spans in memory. The zero value is an empty sink.
+type traceSink struct {
+	mu        sync.Mutex
+	rootSpans []*exporttrace.SpanData
+	children  map[trace.SpanID][]*exporttrace.SpanData
+}
+
+// ExportSpan saves the trace span. It is safe to be called concurrently.
+func (sink *traceSink) ExportSpan(_ context.Context, span *exporttrace.SpanData) {
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if !span.ParentSpanID.IsValid() {
+		sink.rootSpans = append(sink.rootSpans, span)
+		return
+	}
+	if sink.children == nil {
+		sink.children = make(map[trace.SpanID][]*exporttrace.SpanData)
+	}
+	sink.children[span.ParentSpanID] = append(sink.children[span.ParentSpanID], span)
+}
+
+const (
+	traceDumpStartWidth   = 14
+	traceDumpEndWidth     = 14
+	traceDumpElapsedWidth = 14
+)
+
+// dump formats the recorded traces as a hierarchial table of spans in the order
+// received. It is safe to call concurrently, including with ExportSpan.
+func (sink *traceSink) dump() string {
+	sb := new(strings.Builder)
+	fmt.Fprintf(sb, "%-*s %-*s %-*s\n",
+		traceDumpStartWidth, "Start",
+		traceDumpEndWidth, "End",
+		traceDumpElapsedWidth, "Elapsed",
+	)
+	sink.mu.Lock()
+	sink.dumpLocked(sb, trace.SpanID{}, 0)
+	sink.mu.Unlock()
+	return sb.String()
+}
+
+func (sink *traceSink) dumpLocked(sb *strings.Builder, parent trace.SpanID, depth int) {
+	const indent = "  "
+	list := sink.rootSpans
+	if parent.IsValid() {
+		list = sink.children[parent]
+	}
+	if depth >= 3 {
+		if len(list) > 0 {
+			writeSpaces(sb, traceDumpStartWidth+traceDumpEndWidth+traceDumpElapsedWidth+3)
+			for i := 0; i < depth; i++ {
+				sb.WriteString(indent)
+			}
+			sb.WriteString("...\n")
+		}
+		return
+	}
+	for _, span := range list {
+		elapsed := span.EndTime.Sub(span.StartTime)
+		fmt.Fprintf(sb, "%-*s %-*s %*.3fs %s\n",
+			traceDumpStartWidth, span.StartTime.Format(longTimeFormat),
+			traceDumpEndWidth, span.EndTime.Format(longTimeFormat),
+			traceDumpElapsedWidth-1, elapsed.Seconds(),
+			strings.Repeat(indent, depth)+span.Name,
+		)
+		sink.dumpLocked(sb, span.SpanContext.SpanID, depth+1)
+	}
+}
+
+func writeSpaces(w io.ByteWriter, n int) {
+	for i := 0; i < n; i++ {
+		w.WriteByte(' ')
+	}
+}

--- a/cmd/yb/remote_build.go
+++ b/cmd/yb/remote_build.go
@@ -186,7 +186,7 @@ func (p *remoteCmd) run(ctx context.Context) error {
 	// Show feedback: end of bootstrap
 	endTime := time.Now()
 	bootTime := endTime.Sub(startTime)
-	log.Infof(ctx, "Bootstrap finished at %s, taking %s", endTime.Format(TIME_FORMAT), bootTime.Truncate(time.Millisecond))
+	log.Infof(ctx, "Bootstrap finished at %s, taking %s", endTime.Format(longTimeFormat), bootTime.Truncate(time.Millisecond))
 
 	// Process patches
 	startTime = time.Now()
@@ -277,7 +277,7 @@ func (p *remoteCmd) run(ctx context.Context) error {
 	// Show feedback: end of patch generation
 	endTime = time.Now()
 	patchTime := endTime.Sub(startTime)
-	log.Infof(ctx, "Patch finished at %s, taking %s", endTime.Format(TIME_FORMAT), patchTime.Truncate(time.Millisecond))
+	log.Infof(ctx, "Patch finished at %s, taking %s", endTime.Format(longTimeFormat), patchTime.Truncate(time.Millisecond))
 	if len(p.patchPath) > 0 && len(p.patchData) > 0 {
 		if err := p.savePatch(); err != nil {
 			log.Warnf(ctx, "Unable to save copy of generated patch: %v", err)
@@ -647,7 +647,7 @@ func (cmd *remoteCmd) submitBuild(ctx context.Context, project *apiProject, tagM
 
 	endTime := time.Now()
 	submitTime := endTime.Sub(startTime)
-	log.Infof(ctx, "Submission finished at %s, taking %s", endTime.Format(TIME_FORMAT), submitTime.Truncate(time.Millisecond))
+	log.Infof(ctx, "Submission finished at %s, taking %s", endTime.Format(longTimeFormat), submitTime.Truncate(time.Millisecond))
 
 	startTime = time.Now()
 
@@ -688,7 +688,7 @@ func (cmd *remoteCmd) submitBuild(ctx context.Context, project *apiProject, tagM
 				buildSetupFinished = true
 				endTime := time.Now()
 				setupTime := endTime.Sub(startTime)
-				log.Infof(ctx, "Set up finished at %s, taking %s", endTime.Format(TIME_FORMAT), setupTime.Truncate(time.Millisecond))
+				log.Infof(ctx, "Set up finished at %s, taking %s", endTime.Format(longTimeFormat), setupTime.Truncate(time.Millisecond))
 				if cmd.publicRepo {
 					log.Infof(ctx, "Building a public repository: '%s'", project.Repository)
 				}


### PR DESCRIPTION
Will still get printed in CI, but doesn't take up space for interactive builds.

Turned `yb platform` into an alias for `yb version`, so users only have to use a single command for diagnostics.

Extracted logging code to output.go in preparation for larger output cleanup.

Updates ch-4043

Sample output:

```plain
yb version v0.7.0-alpha1
Channel: development
Host OS: darwin/amd64 20.3.0 (6 cores)
Date: 2021-04-22T00:03:29Z
Commit: 85d6fa50c914545f8a68d7a8e21caeee6254d0de
```