### PR TITLE
Make output more compact and easier to read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 -  Commands run as part of `build`, `exec`, or `run` now run without Docker by
    default. You can get the old behavior by running with `--mode=container`.
+-  Tool output has been changed to be more compact, to be easier to trace
+   command output, and to include more timing information.
 -  `yb platform` is now an alias for `yb version`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog][], and this project adheres to
 -  A new `--mode` option for `build`, `exec`, and `run` allows specifying
    whether commands should be run inside or outside Docker.
 -  yb now obeys the `DOCKER_HOST` environment variable.
+-  yb now obeys the [`NO_COLOR` environment variable][] and propagates it to the
+   build environment.
+
+[`NO_COLOR` environment variable]: https://no-color.org/
 
 ### Changed
 

--- a/cmd/yb/build.go
+++ b/cmd/yb/build.go
@@ -148,7 +148,7 @@ func (b *buildCmd) run(ctx context.Context) error {
 		return alreadyLoggedError{buildError}
 	}
 
-	fmt.Printf("%sBUILD SUCCEEDED%s ️✔️\n", style.buildResult(true), style.reset())
+	fmt.Printf("%sBUILD PASSED%s ️✔️\n", style.buildResult(true), style.reset())
 	return nil
 }
 

--- a/cmd/yb/build.go
+++ b/cmd/yb/build.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -99,6 +99,7 @@ func (b *buildCmd) run(ctx context.Context, buildTargetName string) error {
 	startTime := time.Now()
 	ctx, span := ybtrace.Start(ctx, "Build", trace.WithNewRoot())
 	defer span.End()
+	ctx = withStdoutLogs(ctx)
 
 	log.Infof(ctx, "Build started at %s", startTime.Format(longTimeFormat))
 
@@ -113,10 +114,10 @@ func (b *buildCmd) run(ctx context.Context, buildTargetName string) error {
 	buildTargets := yb.BuildOrder(desired)
 
 	// Do the build!
-	startSection("BUILD")
 	log.Debugf(ctx, "Building package %s in %s...", targetPackage.Name, targetPackage.Path)
 
 	buildError := doTargetList(ctx, targetPackage, buildTargets, &doOptions{
+		output:        os.Stdout,
 		executionMode: b.mode,
 		dockerClient:  dockerClient,
 		dataDirs:      dataDirs,
@@ -128,27 +129,27 @@ func (b *buildCmd) run(ctx context.Context, buildTargetName string) error {
 	})
 	if buildError != nil {
 		span.SetStatus(codes.Unknown, buildError.Error())
+		log.Errorf(ctx, "%v", buildError)
 	}
 	span.End()
 	endTime := time.Now()
 	buildTime := endTime.Sub(startTime)
 
-	log.Infof(ctx, "")
-	log.Infof(ctx, "Build finished at %s, taking %s", endTime.Format(longTimeFormat), buildTime)
-	log.Infof(ctx, "")
+	fmt.Printf("\nBuild finished at %s, taking %v\n\n", endTime.Format(longTimeFormat), buildTime.Truncate(time.Millisecond))
+	fmt.Println(buildTraces.dump())
 
-	log.Infof(ctx, "%s", buildTraces.dump())
-
+	style := termStylesFromEnv()
 	if buildError != nil {
-		subSection("BUILD FAILED")
-		return buildError
+		fmt.Printf("%sBUILD FAILED%s ❌\n", style.buildResult(false), style.reset())
+		return alreadyLoggedError{buildError}
 	}
 
-	subSection("BUILD SUCCEEDED")
+	fmt.Printf("%sBUILD SUCCEEDED%s ️✔️\n", style.buildResult(true), style.reset())
 	return nil
 }
 
 type doOptions struct {
+	output          io.Writer
 	dataDirs        *ybdata.Dirs
 	downloader      *ybdata.Downloader
 	executionMode   executionMode
@@ -194,6 +195,11 @@ func doTargetList(ctx context.Context, pkg *yb.Package, targets []*yb.Target, op
 }
 
 func doTarget(ctx context.Context, pkg *yb.Package, target *yb.Target, opts *doOptions) error {
+	style := termStylesFromEnv()
+	fmt.Printf("\n🎯 %sTarget: %s%s\n", style.target(), target.Name, style.reset())
+
+	ctx = withLogPrefix(ctx, target.Name)
+
 	bio, err := newBiome(ctx, target, newBiomeOptions{
 		packageDir:      pkg.Path,
 		dataDirs:        opts.dataDirs,
@@ -212,15 +218,17 @@ func doTarget(ctx context.Context, pkg *yb.Package, target *yb.Target, opts *doO
 			log.Warnf(ctx, "Clean up environment: %v", err)
 		}
 	}()
+	output := newLinePrefixWriter(opts.output, target.Name)
 	sys := build.Sys{
 		Biome:           bio,
 		Downloader:      opts.downloader,
 		DockerClient:    opts.dockerClient,
 		DockerNetworkID: opts.dockerNetworkID,
-		Stdout:          os.Stdout,
-		Stderr:          os.Stderr,
+
+		Stdout: output,
+		Stderr: output,
 	}
-	execBiome, err := build.Setup(ctx, sys, target)
+	execBiome, err := build.Setup(withLogPrefix(ctx, setupLogPrefix), sys, target)
 	if err != nil {
 		return err
 	}
@@ -237,34 +245,15 @@ func doTarget(ctx context.Context, pkg *yb.Package, target *yb.Target, opts *doO
 		return nil
 	}
 
-	subSection(fmt.Sprintf("Build target: %s", target.Name))
-	log.Infof(ctx, "Executing build steps...")
-	return build.Execute(ctx, sys, target)
+	return build.Execute(withStdoutLogs(ctx), sys, announceCommand, target)
 }
 
-// Because, why not?
-// Based on https://github.com/sindresorhus/is-docker/blob/master/index.js and https://github.com/moby/moby/issues/18355
-// Discussion is not settled yet: https://stackoverflow.com/questions/23513045/how-to-check-if-a-process-is-running-inside-docker-container#25518538
-func insideTheMatrix() bool {
-	hasDockerEnv := pathExists("/.dockerenv")
-	hasDockerCGroup := false
-	dockerCGroupPath := "/proc/self/cgroup"
-	if pathExists(dockerCGroupPath) {
-		contents, _ := ioutil.ReadFile(dockerCGroupPath)
-		hasDockerCGroup = strings.Count(string(contents), "docker") > 0
-	}
-	return hasDockerEnv || hasDockerCGroup
+func announceCommand(cmdString string) {
+	style := termStylesFromEnv()
+	fmt.Printf("%s> %s%s\n", style.command(), cmdString, style.reset())
 }
 
 func pathExists(path string) bool {
 	_, err := os.Lstat(path)
 	return !os.IsNotExist(err)
-}
-
-func startSection(name string) {
-	fmt.Printf(" === %s ===\n", name)
-}
-
-func subSection(name string) {
-	fmt.Printf(" -- %s -- \n", name)
 }

--- a/cmd/yb/exec.go
+++ b/cmd/yb/exec.go
@@ -98,7 +98,7 @@ func (b *execCmd) run(ctx context.Context) error {
 		Stdout:          os.Stdout,
 		Stderr:          os.Stderr,
 	}
-	execBiome, err := build.Setup(ctx, sys, execTarget)
+	execBiome, err := build.Setup(withLogPrefix(ctx, execTarget.Name+setupLogPrefix), sys, execTarget)
 	if err != nil {
 		return err
 	}
@@ -108,5 +108,5 @@ func (b *execCmd) run(ctx context.Context) error {
 			log.Errorf(ctx, "Clean up environment %s: %v", b.execEnvName, err)
 		}
 	}()
-	return build.Execute(ctx, sys, execTarget)
+	return build.Execute(ctx, sys, announceCommand, execTarget)
 }

--- a/cmd/yb/output.go
+++ b/cmd/yb/output.go
@@ -230,7 +230,7 @@ const (
 // received. It is safe to call concurrently, including with ExportSpan.
 func (sink *traceSink) dump() string {
 	sb := new(strings.Builder)
-	fmt.Fprintf(sb, "%-*s %-*s %-*s\n",
+	fmt.Fprintf(sb, "%-*s %-*s %*s\n",
 		traceDumpStartWidth, "Start",
 		traceDumpEndWidth, "End",
 		traceDumpElapsedWidth, "Elapsed",

--- a/cmd/yb/output_test.go
+++ b/cmd/yb/output_test.go
@@ -1,0 +1,110 @@
+// Copyright 2021 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		 https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLinePrefixWriter(t *testing.T) {
+	start := time.Date(2021, time.April, 21, 14, 10, 23, 0, time.FixedZone("America/Los_Angeles", -7*60*60))
+	const defaultPrefix = "default"
+	const defaultPaddedPrefix = "default           |"
+	tests := []struct {
+		name   string
+		prefix string
+		writes []string
+		want   string
+	}{
+		{
+			name:   "Empty",
+			prefix: defaultPrefix,
+			writes: []string{""},
+			want:   "",
+		},
+		{
+			name:   "PartialLine",
+			prefix: defaultPrefix,
+			writes: []string{"foo"},
+			want:   "14:10:23 " + defaultPaddedPrefix + " foo",
+		},
+		{
+			name:   "FullLine",
+			prefix: defaultPrefix,
+			writes: []string{"foo\n"},
+			want:   "14:10:23 " + defaultPaddedPrefix + " foo\n",
+		},
+		{
+			name:   "MultipleLines/OneWrite",
+			prefix: defaultPrefix,
+			writes: []string{"foo\nbar\n"},
+			want: "14:10:23 " + defaultPaddedPrefix + " foo\n" +
+				"14:10:23 " + defaultPaddedPrefix + " bar\n",
+		},
+		{
+			name:   "MultipleLines/MultipleWrites",
+			prefix: defaultPrefix,
+			writes: []string{"foo\n", "bar\n"},
+			want: "14:10:23 " + defaultPaddedPrefix + " foo\n" +
+				"14:10:24 " + defaultPaddedPrefix + " bar\n",
+		},
+		{
+			name:   "MultipleLines/Split",
+			prefix: defaultPrefix,
+			writes: []string{"foo\nb", "ar\n"},
+			want: "14:10:23 " + defaultPaddedPrefix + " foo\n" +
+				"14:10:23 " + defaultPaddedPrefix + " bar\n",
+		},
+		{
+			name:   "RSpecDots",
+			prefix: defaultPrefix,
+			writes: []string{".", ".", ".", ".", "\n"},
+			want:   "14:10:23 " + defaultPaddedPrefix + " ....\n",
+		},
+		{
+			name:   "LongPrefix",
+			prefix: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			writes: []string{"foo\n"},
+			want:   "14:10:23 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx| foo\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			currTime := start
+			out := new(strings.Builder)
+			w := newLinePrefixWriter(out, test.prefix)
+			w.now = func() time.Time {
+				result := currTime
+				currTime = currTime.Add(1 * time.Second)
+				return result
+			}
+			for i, data := range test.writes {
+				if n, err := io.WriteString(w, data); n != len(data) || err != nil {
+					t.Errorf("Write[%d](%q) = %d, %v; want %d, <nil>", i, data, n, err, len(data))
+				}
+			}
+			if diff := cmp.Diff(test.want, out.String()); diff != "" {
+				t.Errorf("Output (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/yb/run.go
+++ b/cmd/yb/run.go
@@ -81,6 +81,7 @@ func (b *runCmd) run(ctx context.Context, args []string) error {
 
 	// Build dependencies before running command.
 	err = doTargetList(ctx, pkg, targets[:len(targets)-1], &doOptions{
+		output:          os.Stderr,
 		executionMode:   b.mode,
 		dockerClient:    dockerClient,
 		dockerNetworkID: dockerNetworkID,
@@ -120,7 +121,7 @@ func (b *runCmd) run(ctx context.Context, args []string) error {
 		Stdout:          os.Stdout,
 		Stderr:          os.Stderr,
 	}
-	execBiome, err := build.Setup(ctx, sys, execTarget)
+	execBiome, err := build.Setup(withLogPrefix(ctx, execTarget.Name+setupLogPrefix), sys, execTarget)
 	if err != nil {
 		return err
 	}

--- a/cmd/yb/styles.go
+++ b/cmd/yb/styles.go
@@ -1,0 +1,91 @@
+// Copyright 2021 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		 https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/yourbase/commons/envvar"
+)
+
+// termStyles generates ANSI escape codes for specific styles.
+// The zero value will not return any special escape codes.
+// https://en.wikipedia.org/wiki/ANSI_escape_code
+type termStyles bool
+
+func termStylesFromEnv() termStyles {
+	if os.Getenv("NO_COLOR") != "" {
+		// https://no-color.org/
+		return false
+	}
+	b, _ := strconv.ParseBool(envvar.Get("CLICOLOR", "1"))
+	return termStyles(b)
+}
+
+// reset returns the escape code to change the output to default settings.
+func (style termStyles) reset() string {
+	if !style {
+		return ""
+	}
+	return "\x1b[0m"
+}
+
+// target returns the escape code for formatting a target section heading.
+func (style termStyles) target() string {
+	if !style {
+		return ""
+	}
+	// Bold
+	return "\x1b[1m"
+}
+
+// command returns the escape code for formatting a command section heading.
+func (style termStyles) command() string {
+	return style.target()
+}
+
+// buildResult returns the escape code for formatting the final result message.
+func (style termStyles) buildResult(success bool) string {
+	switch {
+	case !bool(style):
+		return ""
+	case !success:
+		return style.failure()
+	default:
+		// Bold
+		return "\x1b[1m"
+	}
+}
+
+// failure returns the escape code for formatting error messages.
+func (style termStyles) failure() string {
+	if !style {
+		return ""
+	}
+	// Red, but not bold to avoid using "bright red".
+	return "\x1b[31m"
+}
+
+// debug returns the escape code for formatting debugging information.
+func (style termStyles) debug() string {
+	if !style {
+		return ""
+	}
+	// Gray
+	return "\x1b[90m"
+}

--- a/internal/biome/biome.go
+++ b/internal/biome/biome.go
@@ -183,7 +183,7 @@ func (l Local) Run(ctx context.Context, invoke *Invocation) error {
 	if len(invoke.Argv) == 0 {
 		return fmt.Errorf("local run: argv empty")
 	}
-	log.Infof(ctx, "Run: %s", strings.Join(invoke.Argv, " "))
+	log.Debugf(ctx, "Run: %s", strings.Join(invoke.Argv, " "))
 	log.Debugf(ctx, "Environment:\n%v", invoke.Env)
 	dir := invoke.Dir
 	if !filepath.IsAbs(invoke.Dir) {

--- a/internal/biome/biome.go
+++ b/internal/biome/biome.go
@@ -200,6 +200,9 @@ func (l Local) Run(ctx context.Context, invoke *Invocation) error {
 		"LOGNAME=" + os.Getenv("LOGNAME"),
 		"USER=" + os.Getenv("USER"),
 	}
+	if v, ok := os.LookupEnv("NO_COLOR"); ok {
+		c.Env = append(c.Env, "NO_COLOR="+v)
+	}
 	c.Env = appendStandardEnv(c.Env, runtime.GOOS)
 	c.Env = invoke.Env.appendTo(c.Env, os.Getenv("PATH"), filepath.ListSeparator)
 	c.Dir = dir

--- a/internal/biome/docker.go
+++ b/internal/biome/docker.go
@@ -255,7 +255,7 @@ func (c *Container) Run(ctx context.Context, invoke *Invocation) error {
 		return fmt.Errorf("run in container %s: argv empty", c.id)
 	}
 
-	log.Infof(ctx, "Run (Docker): %s", strings.Join(invoke.Argv, " "))
+	log.Debugf(ctx, "Run (Docker): %s", strings.Join(invoke.Argv, " "))
 	log.Debugf(ctx, "Running in container %s", c.id)
 	log.Debugf(ctx, "Environment:\n%v", invoke.Env)
 

--- a/internal/biome/docker.go
+++ b/internal/biome/docker.go
@@ -272,6 +272,9 @@ func (c *Container) Run(ctx context.Context, invoke *Invocation) error {
 		// TODO(light): Set LOGNAME and USER.
 		"HOME=" + c.dirs.Home,
 	}
+	if v, ok := os.LookupEnv("NO_COLOR"); ok {
+		opts.Env = append(opts.Env, "NO_COLOR="+v)
+	}
 	opts.Env = appendStandardEnv(opts.Env, c.Describe().OS)
 	opts.Env = invoke.Env.appendTo(opts.Env, c.path, ':')
 	if slashpath.IsAbs(invoke.Dir) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -38,7 +38,9 @@ type Sys = buildpack.Sys
 
 // Execute runs the given phase. It assumes that the phase's dependencies are
 // already available in the biome.
-func Execute(ctx context.Context, sys Sys, target *yb.Target) (err error) {
+//
+// announce is called before every command run if not nil.
+func Execute(ctx context.Context, sys Sys, announce func(string), target *yb.Target) (err error) {
 	ctx, span := ybtrace.Start(ctx, "Build "+target.Name, trace.WithAttributes(
 		label.String("target", target.Name),
 	))
@@ -63,6 +65,9 @@ func Execute(ctx context.Context, sys Sys, target *yb.Target) (err error) {
 		}
 	}
 	for _, cmdString := range target.Commands {
+		if announce != nil {
+			announce(cmdString)
+		}
 		newWorkDir, err := runCommand(ctx, sys, workDir, cmdString)
 		if err != nil {
 			return fmt.Errorf("build %s: %w", target.Name, err)

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -164,7 +164,7 @@ func TestExecute(t *testing.T) {
 					return nil
 				},
 			}
-			err := Execute(ctx, Sys{Biome: bio}, test.target)
+			err := Execute(ctx, Sys{Biome: bio}, nil, test.target)
 			if err != nil {
 				if test.wantError {
 					t.Logf("Build: %v (expected)", err)


### PR DESCRIPTION
Build output now includes a target and command heading. Info-level log lines no longer have the unhelpful "INFO" prefix. All non-error build output now goes to stdout so someone who wants a more quiet experience for a successful build can redirect to `/dev/null`.

Individual lines of command and log output now also include the target they are running for and the time the line was outputted. This serves to both visually group outputs by command as well as provide fine-grained timing information.

Fixes ch-4043
Fixes ch-4040

Terminal output for a successful build:

![Screenshot of terminal output from a successful build](https://user-images.githubusercontent.com/181535/115735209-268d6580-a33f-11eb-8d44-5ad5aade1ff4.png)

Terminal output for a failed build:

![Screenshot of terminal output from a failed build](https://user-images.githubusercontent.com/181535/115735350-43c23400-a33f-11eb-9b61-6546ef6f1537.png)

For comparison, output from the same build on yb v0.6.3:

![Screenshot of terminal output from a successful build in yb v0.6.3. It is longer and less organized.](https://user-images.githubusercontent.com/181535/115735467-5b99b800-a33f-11eb-9a65-29b160aa5a66.png)

FYI @amyhua