### PR TITLE
Use topological sort to compute build order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 -  A new `--mode` option for `build`, `exec`, and `run` allows specifying
    whether commands should be run inside or outside Docker.
+-  `yb build` can now build multiple targets in one invocation.
 -  Build environments will now pick up credentials from `$HOME/.netrc` after any
    credentials from `$XDG_CONFIG_HOME/yb/netrc`. This can be overridden with the
    `NETRC` environment variable. To revert to the previous behavior, set
    `NETRC=/dev/null`.
 -  yb now obeys the `DOCKER_HOST` environment variable.
+-  `yb checkconfig` and other commands that read `.yourbase.yml` will display an
+   error if the targets have a dependency cycle.
 
 ### Changed
 
@@ -28,6 +31,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 -  `yb init` no longer crashes when not given a `--lang` flag if there was
    a problem connecting to the Docker daemon.
+-  `yb build` and `yb run` now build indirect dependencies, not just
+   direct dependencies.
 
 ### Deprecated
 

--- a/cmd/yb/build.go
+++ b/cmd/yb/build.go
@@ -24,6 +24,7 @@ import (
 )
 
 type buildCmd struct {
+	targetNames      []string
 	env              []commandLineEnv
 	netrcFiles       []string
 	execPrefix       string
@@ -34,29 +35,27 @@ type buildCmd struct {
 func newBuildCmd() *cobra.Command {
 	b := new(buildCmd)
 	c := &cobra.Command{
-		Use:   "build [options] [TARGET]",
-		Short: "Build a target",
-		Long: `Builds a target in the current package. If no argument is given, ` +
+		Use:   "build [options] [TARGET [...]]",
+		Short: "Build target(s)",
+		Long: `Builds one or more targets in the current package. If no argument is given, ` +
 			`uses the target named "` + yb.DefaultTarget + `", if there is one.` +
 			"\n\n" +
 			`yb build will search for the .yourbase.yml file in the current directory ` +
 			`and its parent directories. The target's commands will be run in the ` +
 			`directory the .yourbase.yml file appears in.`,
-		Args:                  cobra.MaximumNArgs(1),
+		Args:                  cobra.ArbitraryArgs,
 		DisableFlagsInUseLine: true,
 		SilenceErrors:         true,
 		SilenceUsage:          true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			target := yb.DefaultTarget
-			if len(args) > 0 {
-				target = args[0]
+			if len(args) == 0 {
+				b.targetNames = []string{yb.DefaultTarget}
+			} else {
+				b.targetNames = args
 			}
-			return b.run(cmd.Context(), target)
+			return b.run(cmd.Context())
 		},
 		ValidArgsFunction: func(cc *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) > 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
 			return autocompleteTargetName(toComplete)
 		},
 	}
@@ -68,7 +67,7 @@ func newBuildCmd() *cobra.Command {
 	return c
 }
 
-func (b *buildCmd) run(ctx context.Context, buildTargetName string) error {
+func (b *buildCmd) run(ctx context.Context) error {
 	// Set up trace sink.
 	buildTraces := new(traceSink)
 	tp, err := sdktrace.NewProvider(sdktrace.WithSyncer(buildTraces))
@@ -106,11 +105,15 @@ func (b *buildCmd) run(ctx context.Context, buildTargetName string) error {
 	if err != nil {
 		return err
 	}
-	desired := targetPackage.Targets[buildTargetName]
-	if desired == nil {
-		return fmt.Errorf("%s: no such target (found: %s)", buildTargetName, strings.Join(listTargetNames(targetPackage.Targets), ", "))
+	desired := make([]*yb.Target, 0, len(b.targetNames))
+	for _, name := range b.targetNames {
+		target := targetPackage.Targets[name]
+		if target == nil {
+			return fmt.Errorf("%s: no such target (found: %s)", name, strings.Join(listTargetNames(targetPackage.Targets), ", "))
+		}
+		desired = append(desired, target)
 	}
-	buildTargets := yb.BuildOrder(desired)
+	buildTargets := yb.BuildOrder(desired...)
 
 	// Do the build!
 	startSection("BUILD")

--- a/package_test.go
+++ b/package_test.go
@@ -1,0 +1,125 @@
+// Copyright 2021 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		 https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package yb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBuildOrder(t *testing.T) {
+	tests := []struct {
+		name       string
+		desired    []string
+		acceptable [][]string
+	}{
+		{
+			name:    "Empty",
+			desired: []string{},
+			acceptable: [][]string{
+				{},
+			},
+		},
+		{
+			name:    "Leaf",
+			desired: []string{"default"},
+			acceptable: [][]string{
+				{"default"},
+			},
+		},
+		{
+			name:    "DirectDep",
+			desired: []string{"a"},
+			acceptable: [][]string{
+				{"b", "a"},
+			},
+		},
+		{
+			name:    "SharedDep",
+			desired: []string{"a", "b"},
+			acceptable: [][]string{
+				{"c", "b", "a"},
+				{"c", "a", "b"},
+			},
+		},
+		{
+			name:    "NamedDep",
+			desired: []string{"a", "b"},
+			acceptable: [][]string{
+				{"b", "a"},
+			},
+		},
+		{
+			name:    "IndirectDep",
+			desired: []string{"a"},
+			acceptable: [][]string{
+				{"c", "b", "a"},
+			},
+		},
+		{
+			name:    "DirectAndIndirectDep",
+			desired: []string{"a"},
+			acceptable: [][]string{
+				{"c", "b", "a"},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configData, err := os.ReadFile(filepath.Join("testdata", "BuildOrder", test.name+".yml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			configPath := filepath.Join(dir, PackageConfigFilename)
+			if err := os.WriteFile(configPath, configData, 0o666); err != nil {
+				t.Fatal(err)
+			}
+			pkg, err := LoadPackage(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			desired := make([]*Target, 0, len(test.desired))
+			for _, name := range test.desired {
+				target := pkg.Targets[name]
+				if target == nil {
+					t.Fatalf("target %q not found", name)
+				}
+				desired = append(desired, target)
+			}
+			got := BuildOrder(desired...)
+			gotNames := make([]string, 0, len(got))
+			for _, target := range got {
+				gotNames = append(gotNames, target.Name)
+			}
+			for _, wantNames := range test.acceptable {
+				if cmp.Equal(wantNames, gotNames) {
+					return
+				}
+			}
+			t.Error("Bad ordering:", gotNames)
+			t.Log("Wanted one of:")
+			for _, wantNames := range test.acceptable {
+				t.Log(wantNames)
+			}
+		})
+	}
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -34,8 +34,9 @@ func TestLoadPackage(t *testing.T) {
 	}
 	// Source files are under testdata/LoadPackage.
 	tests := []struct {
-		name string
-		want *Package
+		name      string
+		want      *Package
+		wantError bool
 	}{
 		{
 			name: "Empty",
@@ -252,13 +253,28 @@ func TestLoadPackage(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "Cycle",
+			wantError: true,
+		},
+		{
+			name:      "SelfCycle",
+			wantError: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			configPath := filepath.Join(packageDir, filepath.FromSlash(test.name+".yml"))
 			got, err := LoadPackage(configPath)
 			if err != nil {
-				t.Fatal("LoadPackage:", err)
+				t.Log("LoadPackage:", err)
+				if !test.wantError {
+					t.Fail()
+				}
+				return
+			}
+			if test.wantError {
+				t.Fatal("LoadPackage did not return an error as expected")
 			}
 			if want := filepath.Dir(configPath); got.Path != want {
 				t.Errorf("pkg.Path = %q; want %q", got.Path, want)

--- a/testdata/BuildOrder/DirectAndIndirectDep.yml
+++ b/testdata/BuildOrder/DirectAndIndirectDep.yml
@@ -1,0 +1,6 @@
+build_targets:
+  - name: a
+    build_after: [b, c]
+  - name: b
+    build_after: [c]
+  - name: c

--- a/testdata/BuildOrder/DirectDep.yml
+++ b/testdata/BuildOrder/DirectDep.yml
@@ -1,0 +1,4 @@
+build_targets:
+  - name: a
+    build_after: [b]
+  - name: b

--- a/testdata/BuildOrder/IndirectDep.yml
+++ b/testdata/BuildOrder/IndirectDep.yml
@@ -1,0 +1,6 @@
+build_targets:
+  - name: a
+    build_after: [b]
+  - name: b
+    build_after: [c]
+  - name: c

--- a/testdata/BuildOrder/Leaf.yml
+++ b/testdata/BuildOrder/Leaf.yml
@@ -1,0 +1,2 @@
+build_targets:
+  - name: default

--- a/testdata/BuildOrder/NamedDep.yml
+++ b/testdata/BuildOrder/NamedDep.yml
@@ -1,0 +1,4 @@
+build_targets:
+  - name: a
+    build_after: [b]
+  - name: b

--- a/testdata/BuildOrder/SharedDep.yml
+++ b/testdata/BuildOrder/SharedDep.yml
@@ -1,0 +1,6 @@
+build_targets:
+  - name: a
+    build_after: [c]
+  - name: b
+    build_after: [c]
+  - name: c

--- a/testdata/LoadPackage/Cycle.yml
+++ b/testdata/LoadPackage/Cycle.yml
@@ -1,0 +1,7 @@
+build_targets:
+  - name: foo
+    build_after:
+      - bar
+  - name: bar
+    build_after:
+      - foo

--- a/testdata/LoadPackage/SelfCycle.yml
+++ b/testdata/LoadPackage/SelfCycle.yml
@@ -1,0 +1,4 @@
+build_targets:
+  - name: foo
+    build_after:
+      - foo


### PR DESCRIPTION
With this comes the ability to specify multiple targets on the command line and have them run in the correct order.

Fixes ch-2750