### PR TITLE
Clean up `yb run` output

### DIFF
--- a/cmd/yb/exec.go
+++ b/cmd/yb/exec.go
@@ -59,6 +59,8 @@ func (b *execCmd) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	ctx = withLogOutput(ctx, os.Stdout)
 	pkg, _, err := findPackage()
 	if err != nil {
 		return err
@@ -109,5 +111,5 @@ func (b *execCmd) run(ctx context.Context) error {
 			log.Errorf(ctx, "Clean up environment %s: %v", b.execEnvName, err)
 		}
 	}()
-	return build.Execute(ctx, sys, announceCommand, execTarget)
+	return build.Execute(ctx, sys, announceCommand(os.Stdout), execTarget)
 }

--- a/cmd/yb/run.go
+++ b/cmd/yb/run.go
@@ -96,6 +96,7 @@ func (b *runCmd) run(ctx context.Context, args []string) error {
 	}
 
 	// Run command.
+	announceTarget(os.Stderr, execTarget.Name)
 	bio, err := newBiome(ctx, execTarget, newBiomeOptions{
 		executionMode:   b.mode,
 		packageDir:      pkg.Path,
@@ -119,7 +120,7 @@ func (b *runCmd) run(ctx context.Context, args []string) error {
 		Downloader:      downloader,
 		DockerClient:    dockerClient,
 		DockerNetworkID: dockerNetworkID,
-		Stdout:          os.Stdout,
+		Stdout:          os.Stderr,
 		Stderr:          os.Stderr,
 	}
 	execBiome, err := build.Setup(withLogPrefix(ctx, execTarget.Name+setupLogPrefix), sys, execTarget)
@@ -132,6 +133,7 @@ func (b *runCmd) run(ctx context.Context, args []string) error {
 		}
 	}()
 	subdirElems := strings.Split(subdir, string(filepath.Separator))
+	announceCommand(os.Stderr)(strings.Join(args, " "))
 	return execBiome.Run(ctx, &biome.Invocation{
 		Argv:        args,
 		Stdin:       os.Stdin,

--- a/cmd/yb/run_test.go
+++ b/cmd/yb/run_test.go
@@ -1,0 +1,67 @@
+// Copyright 2021 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		 https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"zombiezen.com/go/log/testlog"
+)
+
+func TestRunCommand(t *testing.T) {
+	cfg, err := ioutil.ReadFile(filepath.Join("testdata", "TestRunCmd", "config.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cdTempDir(t)
+	if err := ioutil.WriteFile(".yourbase.yml", cfg, 0666); err != nil {
+		t.Fatal(err)
+	}
+	outFile, err := os.Create("out.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFile.Close()
+	oldStdout := os.Stdout
+	os.Stdout = outFile
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	ctx := testlog.WithTB(context.Background(), t)
+	c := newRunCmd()
+	const want = "foo\n"
+	c.SetArgs([]string{"echo", strings.TrimSuffix(want, "\n")})
+	if err := c.ExecuteContext(ctx); err != nil {
+		t.Error("yb run:", err)
+	}
+	if _, err := outFile.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ioutil.ReadAll(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("stdout = %q; want %q", got, want)
+	}
+}

--- a/cmd/yb/testdata/TestRunCmd/config.yml
+++ b/cmd/yb/testdata/TestRunCmd/config.yml
@@ -1,0 +1,20 @@
+# Copyright 2021 YourBase Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+build_targets:
+  - name: default
+    commands:
+      - "true"


### PR DESCRIPTION
I made some of the logging output settings more configurable so that `doOptions.output` is respected. This is especially important for `yb run` so that stdout is unperturbed.

Before:

```plain
$ yb run -t test -- echo hi
08:47:35 test.deps         | Configuring build tool go:1.16.3...
08:47:35 test.deps         | Go v1.16.3 located in /Users/light/.cache/yb/workspaces/9ed612c047c7/test/darwin/amd64/.cache/yb/tools/go/go1.16.3
hi
```

After:

```plain
$ yb run -t test -- echo hi

🎯 Target: test
08:45:33 test.deps         | Configuring build tool go:1.16.3...
08:45:33 test.deps         | Go v1.16.3 located in /Users/light/.cache/yb/workspaces/9ed612c047c7/test/darwin/amd64/.cache/yb/tools/go/go1.16.3
hi
```

Fixes ch-4760