### PR TITLE
Allow `exec` dependencies to be specified under the `exec` section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
    user about them.
 -  yb now obeys the [`NO_COLOR` environment variable][] and propagates it to the
    build environment.
+-  `exec` build packs can now be specified under `exec.dependencies.runtime` in
+   `.yourbase.yml`.
 
 [`NO_COLOR` environment variable]: https://no-color.org/
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -264,20 +264,18 @@ often used to start a local development server for the project. The `exec`
 section has the same properties as a target (as described in the
 [Build Targets section](#build-targets)), with a few small differences:
 
-- Build packs are specified in the top-level `dependencies` section under
-  `runtime` instead of under the top-level `exec` section.
 - Executable targets do not support `build_after`.
 - The `environment` attribute is a map of `KEY=VALUE` lists. The `default`
   environment is used if the `yb exec --environment` flag is not specified.
 
 ```yaml
-dependencies:
-  runtime:
-    - python:3.9.2
 exec:
   container:
     ports:
       - 8080:8080
+  dependencies:
+    runtime:
+      - python:3.9.2
   environment:
     default:
       - DJANGO_SETTINGS_MODULE=mysite.settings

--- a/parse.go
+++ b/parse.go
@@ -202,6 +202,7 @@ type execPhase struct {
 }
 
 type execDependencies struct {
+	Runtime    []string                        `yaml:"runtime"`
 	Containers map[string]*containerDefinition `yaml:"containers"`
 }
 
@@ -212,6 +213,9 @@ func parseExecPhase(pkg *Package, manifest *buildManifest) (map[string]*Target, 
 	buildpacks := make(map[string]BuildpackSpec)
 	if err := parseBuildpacks(buildpacks, manifest.Dependencies.Runtime); err != nil {
 		return nil, fmt.Errorf("top-level runtime dependencies: %w", err)
+	}
+	if err := parseBuildpacks(buildpacks, manifest.Exec.Dependencies.Runtime); err != nil {
+		return nil, fmt.Errorf("exec runtime dependencies: %w", err)
 	}
 	container, err := manifest.Exec.Container.toResource(pkg.Path)
 	if err != nil {

--- a/parse_test.go
+++ b/parse_test.go
@@ -173,7 +173,9 @@ func TestLoadPackage(t *testing.T) {
 						},
 						UseContainer: true,
 						Buildpacks: map[string]BuildpackSpec{
-							"python": "python:3.7.7",
+							"go":     "go:1.16.4",
+							"java":   "java:16+36",
+							"python": "python:3.9.2",
 						},
 						Resources: map[string]*ResourceDefinition{
 							"db": {ContainerDefinition: narwhal.ContainerDefinition{
@@ -200,7 +202,9 @@ func TestLoadPackage(t *testing.T) {
 						},
 						UseContainer: true,
 						Buildpacks: map[string]BuildpackSpec{
-							"python": "python:3.7.7",
+							"go":     "go:1.16.4",
+							"java":   "java:16+36",
+							"python": "python:3.9.2",
 						},
 						Resources: map[string]*ResourceDefinition{
 							"db": {ContainerDefinition: narwhal.ContainerDefinition{

--- a/testdata/LoadPackage/Exec.yml
+++ b/testdata/LoadPackage/Exec.yml
@@ -1,5 +1,6 @@
 dependencies:
   runtime:
+    - go:1.16.4
     - python:3.7.7
 exec:
   container:
@@ -7,6 +8,9 @@ exec:
       - 5000
       - 5001
   dependencies:
+    runtime:
+      - java:16+36
+      - python:3.9.2
     containers:
       db:
         image: yourbase/api_dev_db


### PR DESCRIPTION
Fixes ch-4885

~~**Note to reviewers:** I'm sending this out as draft because it modifies the docs I introduced in #303. Once that PR lands, I'll mark this as ready for review.~~