### PR TITLE
Mark Docker as necessary if starting side containers

### DIFF
--- a/cmd/yb/helpers.go
+++ b/cmd/yb/helpers.go
@@ -100,7 +100,7 @@ type newBiomeOptions struct {
 }
 
 func newBiome(ctx context.Context, target *yb.Target, opts newBiomeOptions) (biome.BiomeCloser, error) {
-	useDocker := willUseDocker(opts.executionMode, []*yb.Target{target})
+	useDocker := willUseDockerForCommands(opts.executionMode, []*yb.Target{target})
 	if useDocker && opts.dockerClient == nil {
 		return nil, fmt.Errorf("set up environment for target %s: docker required but unavailable", target.Name)
 	}
@@ -279,6 +279,15 @@ func showDockerWarningsIfNeeded(ctx context.Context, mode executionMode, targets
 }
 
 func willUseDocker(mode executionMode, targets []*yb.Target) bool {
+	for _, target := range targets {
+		if len(target.Resources) > 0 {
+			return true
+		}
+	}
+	return willUseDockerForCommands(mode, targets)
+}
+
+func willUseDockerForCommands(mode executionMode, targets []*yb.Target) bool {
 	for _, target := range targets {
 		if target.UseContainer {
 			return true


### PR DESCRIPTION
There are two distinct use cases for querying whether a list of targets will use Docker: biome creation and Docker initialization. The former only cares about whether the target specifies a container, but the latter also cares about side containers. I've split the check into two separate functions to make the logic clear and allow easy testing.

This is a bug present in 0.7.0-alpha1, but it is not present in 0.6.  No backporting is necessary.