### PR TITLE
Add some bits to support installing Ruby properly on Apple M1 

### DIFF
--- a/internal/biome/biome.go
+++ b/internal/biome/biome.go
@@ -89,6 +89,7 @@ const (
 const (
 	Intel64 = "amd64"
 	Intel32 = "386"
+	ARM64   = "arm64"
 )
 
 // Dirs holds paths to special directories in a Context.

--- a/internal/buildpack/ruby.go
+++ b/internal/buildpack/ruby.go
@@ -92,12 +92,12 @@ func installRuby(ctx context.Context, sys Sys, spec yb.BuildpackSpec) (biome.Env
 		}
 	}
 
-    buildEnv := map[string]string{"RBENV_ROOT": rbenvDir}
-    // Special bits for older Ruby on M1 
-    if desc.OS == "darwin" && desc.Arch == "arm64" {
-        log.Debugf(ctx, "Setting RUBY_CFLAGS=-DUSE_FFI_CLOSURE_ALLOC to support Apple M1 with older Ruby versions")
-        buildEnv["RUBY_CFLAGS"] = "-DUSE_FFI_CLOSURE_ALLOC"
-    }
+	buildEnv := map[string]string{"RBENV_ROOT": rbenvDir}
+	// Special bits for older Ruby on M1
+	if desc.OS == biome.MacOS && desc.Arch == biome.ARM64 {
+		log.Debugf(ctx, "Setting RUBY_CFLAGS=-DUSE_FFI_CLOSURE_ALLOC to support Apple M1 with older Ruby versions")
+		buildEnv["RUBY_CFLAGS"] = "-DUSE_FFI_CLOSURE_ALLOC"
+	}
 	err := sys.Biome.Run(ctx, &biome.Invocation{
 		Argv: []string{"rbenv", "install", spec.Version()},
 		Env: biome.Environment{


### PR DESCRIPTION
More fixes coming soon; this lets Ruby 2.7.x and earlier compile correctly on M1