### PR TITLE
added message about disabling yourbase for debugging

### DIFF
--- a/docs/python/configuration.md
+++ b/docs/python/configuration.md
@@ -180,6 +180,10 @@ echo ${XDG_STATE_HOME-~/.local/state}/yourbase/python.log
 
 When on, YourBase will not load.
 
+This setting is recommended when using a debugger.  Since YourBase Test
+Selection is designed to skip the execution of code that has not changed, 
+breakpoints will not be hit for tests that are skipped.
+
 Enabling this setting then manually attaching to a test framework using
 `yourbase.attach` produces undefined behavior.
 


### PR DESCRIPTION
@glacials Do you think this rises to the level of being on the main page?  I considered adding a new section and blurp below "### For use in a CI".

I do not want to call it a known issue as that sounds like something we may need to "fix".