### PR TITLE
Condense docs landing page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,14 +3,16 @@
 # Test Acceleration
 
 - Python Test Acceleration
-  - [Getting Started](python/getting-started.md)
-  - [Configuration](python/configuration.md)
-  - [PyPI](https://pypi.org/project/yourbase/)
-- Ruby Acceleration - Coming soon! Contact us at hi@yourbase.io if you
+  - [Getting Started](python/getting-started.md) - ***new users start here!***
+    - [Configuration Options](python/configuration.md)
+  - [PyPI package](https://pypi.org/project/yourbase/)
+- Ruby Test Acceleration - Coming soon! Contact us at hi@yourbase.io if you
   want to join the private beta.
 
-# CI and CLI Documentation
 
+<details>
+  <summary>CI and CLI Documentation</summary>
+  
 - [Installation](installation.md)
 - [Getting Started](getting-started.md)
 - [List of Build Packs](buildpacks.md)
@@ -18,3 +20,5 @@
 - [CLI Settings Reference](cli-settings.md)
 - [CI Acceleration and Caching](ci-caching.md)
 - [Design Philosophy](design-philosophy.md)
+</details>
+


### PR DESCRIPTION
- Make clearer the link to the getting started page
- Hide some of the lower-priority content around CI and CLI