### PR TITLE
Fix image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1><img alt="YourBase" src="docs/images/logo-on-white.jpg" width="384" height="112"></h1>
+<h1><img alt="YourBase" src="https://github.com/yourbase/docs.yourbase.io/raw/main/images/logo-on-white.jpg" width="384" height="112"></h1>
 
 [![YourBase Community Slack](https://img.shields.io/badge/slack-@yourbase/community-blue.svg?logo=slack)](https://slack.yourbase.io)
 


### PR DESCRIPTION
It seems like the image link wasn't updated after the docs moved.